### PR TITLE
Adapt advanced catalog frontend to backend implementation

### DIFF
--- a/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-constants.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-constants.ts
@@ -1,0 +1,628 @@
+// ============================================================================
+// ADVANCED CATALOG CONSTANTS - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// General constants, enums, and configuration values for the catalog system
+// ============================================================================
+
+// ============================================================================
+// SYSTEM CONFIGURATION
+// ============================================================================
+
+export const CATALOG_CONFIG = {
+  // Version Information
+  VERSION: '2.0.0',
+  BUILD: '2024.12.28',
+  API_VERSION: 'v1',
+  
+  // Performance Settings
+  DEFAULT_PAGE_SIZE: 20,
+  MAX_PAGE_SIZE: 100,
+  MIN_PAGE_SIZE: 5,
+  DEFAULT_TIMEOUT: 30000,
+  RETRY_ATTEMPTS: 3,
+  RETRY_DELAY: 1000,
+  CACHE_TTL: 300000, // 5 minutes
+  
+  // Search Configuration
+  MAX_SEARCH_RESULTS: 1000,
+  DEFAULT_SEARCH_LIMIT: 50,
+  AUTOCOMPLETE_DELAY: 300,
+  SUGGESTION_COUNT: 5,
+  FACET_COUNT: 10,
+  
+  // Asset Limits
+  MAX_ASSET_NAME_LENGTH: 255,
+  MAX_DESCRIPTION_LENGTH: 2048,
+  MAX_TAG_COUNT: 20,
+  MAX_COLUMN_COUNT: 1000,
+  MAX_FILE_SIZE: 104857600, // 100MB
+  
+  // Quality Thresholds
+  MIN_QUALITY_SCORE: 0.0,
+  MAX_QUALITY_SCORE: 1.0,
+  DEFAULT_QUALITY_THRESHOLD: 0.8,
+  HIGH_QUALITY_THRESHOLD: 0.9,
+  LOW_QUALITY_THRESHOLD: 0.6,
+  
+  // Lineage Configuration
+  MAX_LINEAGE_DEPTH: 10,
+  DEFAULT_LINEAGE_DEPTH: 3,
+  MAX_LINEAGE_NODES: 500,
+  LINEAGE_BATCH_SIZE: 50,
+  
+  // Analytics Configuration
+  DEFAULT_ANALYTICS_PERIOD: 30, // days
+  MAX_ANALYTICS_PERIOD: 365, // days
+  MIN_ANALYTICS_PERIOD: 1, // day
+  ANALYTICS_REFRESH_INTERVAL: 3600000, // 1 hour
+  
+  // UI Configuration
+  ANIMATION_DURATION: 300,
+  DEBOUNCE_DELAY: 500,
+  TOOLTIP_DELAY: 1000,
+  NOTIFICATION_DURATION: 5000,
+  AUTO_SAVE_INTERVAL: 30000, // 30 seconds
+  
+  // Security Settings
+  SESSION_TIMEOUT: 7200000, // 2 hours
+  MAX_LOGIN_ATTEMPTS: 3,
+  PASSWORD_MIN_LENGTH: 8,
+  TOKEN_REFRESH_THRESHOLD: 300000, // 5 minutes
+  
+  // File Upload
+  ALLOWED_FILE_TYPES: [
+    'application/json',
+    'text/csv',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/parquet',
+    'application/avro'
+  ],
+  
+  // Export Formats
+  EXPORT_FORMATS: ['JSON', 'CSV', 'EXCEL', 'PDF', 'XML'] as const,
+  
+  // Date Formats
+  DATE_FORMAT: 'YYYY-MM-DD',
+  DATETIME_FORMAT: 'YYYY-MM-DD HH:mm:ss',
+  DISPLAY_DATE_FORMAT: 'MMM DD, YYYY',
+  DISPLAY_DATETIME_FORMAT: 'MMM DD, YYYY HH:mm',
+  
+  // Localization
+  DEFAULT_LOCALE: 'en-US',
+  SUPPORTED_LOCALES: ['en-US', 'en-GB', 'fr-FR', 'de-DE', 'es-ES', 'ja-JP', 'zh-CN'] as const,
+  DEFAULT_TIMEZONE: 'UTC',
+  
+  // Feature Flags
+  FEATURES: {
+    AI_ENABLED: true,
+    ML_ENABLED: true,
+    REAL_TIME_UPDATES: true,
+    ADVANCED_ANALYTICS: true,
+    COLLABORATION: true,
+    NOTIFICATIONS: true,
+    DARK_MODE: true,
+    ACCESSIBILITY: true,
+    MOBILE_SUPPORT: true,
+    OFFLINE_MODE: false
+  }
+} as const;
+
+// ============================================================================
+// ASSET CONSTANTS
+// ============================================================================
+
+export const ASSET_CONSTANTS = {
+  // Asset Status Options
+  STATUS_OPTIONS: [
+    { value: 'ACTIVE', label: 'Active', color: 'green' },
+    { value: 'INACTIVE', label: 'Inactive', color: 'gray' },
+    { value: 'DEPRECATED', label: 'Deprecated', color: 'orange' },
+    { value: 'DRAFT', label: 'Draft', color: 'blue' },
+    { value: 'ARCHIVED', label: 'Archived', color: 'red' },
+    { value: 'UNDER_REVIEW', label: 'Under Review', color: 'yellow' }
+  ],
+
+  // Data Asset Types
+  ASSET_TYPES: [
+    { value: 'TABLE', label: 'Table', icon: 'table', description: 'Database table' },
+    { value: 'VIEW', label: 'View', icon: 'eye', description: 'Database view' },
+    { value: 'COLUMN', label: 'Column', icon: 'columns', description: 'Table column' },
+    { value: 'DATABASE', label: 'Database', icon: 'database', description: 'Database instance' },
+    { value: 'SCHEMA', label: 'Schema', icon: 'folder', description: 'Database schema' },
+    { value: 'FILE', label: 'File', icon: 'file', description: 'Data file' },
+    { value: 'API', label: 'API', icon: 'globe', description: 'API endpoint' },
+    { value: 'STREAM', label: 'Stream', icon: 'zap', description: 'Data stream' },
+    { value: 'DASHBOARD', label: 'Dashboard', icon: 'bar-chart', description: 'Analytics dashboard' },
+    { value: 'REPORT', label: 'Report', icon: 'file-text', description: 'Business report' },
+    { value: 'MODEL', label: 'Model', icon: 'cpu', description: 'ML/AI model' }
+  ],
+
+  // Sensitivity Levels
+  SENSITIVITY_LEVELS: [
+    { value: 'PUBLIC', label: 'Public', color: 'green', description: 'Publicly available data' },
+    { value: 'INTERNAL', label: 'Internal', color: 'blue', description: 'Internal use only' },
+    { value: 'CONFIDENTIAL', label: 'Confidential', color: 'orange', description: 'Confidential data' },
+    { value: 'RESTRICTED', label: 'Restricted', color: 'red', description: 'Highly restricted data' },
+    { value: 'TOP_SECRET', label: 'Top Secret', color: 'purple', description: 'Top secret classification' }
+  ],
+
+  // PII Types
+  PII_TYPES: [
+    { value: 'NONE', label: 'None', color: 'gray' },
+    { value: 'NAME', label: 'Name', color: 'blue' },
+    { value: 'EMAIL', label: 'Email', color: 'green' },
+    { value: 'PHONE', label: 'Phone', color: 'orange' },
+    { value: 'SSN', label: 'SSN', color: 'red' },
+    { value: 'CREDIT_CARD', label: 'Credit Card', color: 'purple' },
+    { value: 'ADDRESS', label: 'Address', color: 'yellow' }
+  ],
+
+  // Schema Formats
+  SCHEMA_FORMATS: [
+    { value: 'PARQUET', label: 'Parquet', description: 'Apache Parquet format' },
+    { value: 'AVRO', label: 'Avro', description: 'Apache Avro format' },
+    { value: 'JSON', label: 'JSON', description: 'JavaScript Object Notation' },
+    { value: 'CSV', label: 'CSV', description: 'Comma-separated values' },
+    { value: 'ORC', label: 'ORC', description: 'Optimized Row Columnar' },
+    { value: 'DELTA', label: 'Delta', description: 'Delta Lake format' },
+    { value: 'ICEBERG', label: 'Iceberg', description: 'Apache Iceberg format' }
+  ],
+
+  // Data Types
+  DATA_TYPES: [
+    { value: 'STRING', label: 'String', category: 'Text' },
+    { value: 'INTEGER', label: 'Integer', category: 'Numeric' },
+    { value: 'LONG', label: 'Long', category: 'Numeric' },
+    { value: 'FLOAT', label: 'Float', category: 'Numeric' },
+    { value: 'DOUBLE', label: 'Double', category: 'Numeric' },
+    { value: 'BOOLEAN', label: 'Boolean', category: 'Logical' },
+    { value: 'DATE', label: 'Date', category: 'DateTime' },
+    { value: 'DATETIME', label: 'DateTime', category: 'DateTime' },
+    { value: 'TIMESTAMP', label: 'Timestamp', category: 'DateTime' },
+    { value: 'DECIMAL', label: 'Decimal', category: 'Numeric' },
+    { value: 'ARRAY', label: 'Array', category: 'Complex' },
+    { value: 'STRUCT', label: 'Struct', category: 'Complex' },
+    { value: 'MAP', label: 'Map', category: 'Complex' },
+    { value: 'BINARY', label: 'Binary', category: 'Binary' }
+  ]
+} as const;
+
+// ============================================================================
+// QUALITY CONSTANTS
+// ============================================================================
+
+export const QUALITY_CONSTANTS = {
+  // Quality Dimensions
+  DIMENSIONS: [
+    { id: 'completeness', name: 'Completeness', description: 'Data completeness and coverage', weight: 0.2 },
+    { id: 'accuracy', name: 'Accuracy', description: 'Data accuracy and correctness', weight: 0.25 },
+    { id: 'consistency', name: 'Consistency', description: 'Data consistency across sources', weight: 0.2 },
+    { id: 'validity', name: 'Validity', description: 'Data format and business rule validity', weight: 0.15 },
+    { id: 'uniqueness', name: 'Uniqueness', description: 'Data uniqueness and duplication', weight: 0.1 },
+    { id: 'timeliness', name: 'Timeliness', description: 'Data freshness and currency', weight: 0.1 }
+  ],
+
+  // Quality Scores
+  SCORE_RANGES: [
+    { min: 0.9, max: 1.0, grade: 'EXCELLENT', color: 'green', label: 'Excellent' },
+    { min: 0.8, max: 0.89, grade: 'GOOD', color: 'lime', label: 'Good' },
+    { min: 0.7, max: 0.79, grade: 'FAIR', color: 'yellow', label: 'Fair' },
+    { min: 0.6, max: 0.69, grade: 'POOR', color: 'orange', label: 'Poor' },
+    { min: 0.0, max: 0.59, grade: 'CRITICAL', color: 'red', label: 'Critical' }
+  ],
+
+  // Quality Rule Types
+  RULE_TYPES: [
+    { value: 'COMPLETENESS', label: 'Completeness', category: 'Basic' },
+    { value: 'ACCURACY', label: 'Accuracy', category: 'Basic' },
+    { value: 'CONSISTENCY', label: 'Consistency', category: 'Basic' },
+    { value: 'VALIDITY', label: 'Validity', category: 'Basic' },
+    { value: 'UNIQUENESS', label: 'Uniqueness', category: 'Basic' },
+    { value: 'TIMELINESS', label: 'Timeliness', category: 'Basic' },
+    { value: 'CUSTOM', label: 'Custom', category: 'Advanced' }
+  ],
+
+  // Issue Severities
+  SEVERITIES: [
+    { value: 'LOW', label: 'Low', color: 'blue', priority: 1 },
+    { value: 'MEDIUM', label: 'Medium', color: 'yellow', priority: 2 },
+    { value: 'HIGH', label: 'High', color: 'orange', priority: 3 },
+    { value: 'CRITICAL', label: 'Critical', color: 'red', priority: 4 },
+    { value: 'BLOCKING', label: 'Blocking', color: 'purple', priority: 5 }
+  ],
+
+  // Monitoring Frequencies
+  MONITORING_FREQUENCIES: [
+    { value: 'REAL_TIME', label: 'Real-time', interval: 0 },
+    { value: 'EVERY_MINUTE', label: 'Every minute', interval: 60 },
+    { value: 'EVERY_5_MINUTES', label: 'Every 5 minutes', interval: 300 },
+    { value: 'EVERY_15_MINUTES', label: 'Every 15 minutes', interval: 900 },
+    { value: 'EVERY_HOUR', label: 'Every hour', interval: 3600 },
+    { value: 'DAILY', label: 'Daily', interval: 86400 },
+    { value: 'WEEKLY', label: 'Weekly', interval: 604800 },
+    { value: 'MONTHLY', label: 'Monthly', interval: 2592000 }
+  ]
+} as const;
+
+// ============================================================================
+// LINEAGE CONSTANTS
+// ============================================================================
+
+export const LINEAGE_CONSTANTS = {
+  // Lineage Types
+  TYPES: [
+    { value: 'DIRECT', label: 'Direct', description: 'Direct data flow relationship' },
+    { value: 'INDIRECT', label: 'Indirect', description: 'Indirect data flow through intermediary' },
+    { value: 'DERIVED', label: 'Derived', description: 'Data derived through calculation' },
+    { value: 'AGGREGATED', label: 'Aggregated', description: 'Data aggregated from sources' },
+    { value: 'TRANSFORMED', label: 'Transformed', description: 'Data transformed via ETL process' }
+  ],
+
+  // Lineage Directions
+  DIRECTIONS: [
+    { value: 'UPSTREAM', label: 'Upstream', icon: 'arrow-left', description: 'Data sources' },
+    { value: 'DOWNSTREAM', label: 'Downstream', icon: 'arrow-right', description: 'Data consumers' },
+    { value: 'BIDIRECTIONAL', label: 'Bidirectional', icon: 'arrow-left-right', description: 'Both directions' }
+  ],
+
+  // Transformation Types
+  TRANSFORMATION_TYPES: [
+    { value: 'COPY', label: 'Copy', icon: 'copy', description: 'Direct copy operation' },
+    { value: 'FILTER', label: 'Filter', icon: 'filter', description: 'Data filtering' },
+    { value: 'AGGREGATE', label: 'Aggregate', icon: 'layers', description: 'Data aggregation' },
+    { value: 'JOIN', label: 'Join', icon: 'git-merge', description: 'Data join operation' },
+    { value: 'UNION', label: 'Union', icon: 'git-branch', description: 'Data union operation' },
+    { value: 'TRANSFORM', label: 'Transform', icon: 'shuffle', description: 'Data transformation' },
+    { value: 'CALCULATE', label: 'Calculate', icon: 'calculator', description: 'Calculated field' },
+    { value: 'CLEANSE', label: 'Cleanse', icon: 'soap', description: 'Data cleansing' }
+  ],
+
+  // Visualization Layouts
+  VISUALIZATION_LAYOUTS: [
+    { value: 'HIERARCHICAL', label: 'Hierarchical', description: 'Tree-like hierarchy' },
+    { value: 'FORCE_DIRECTED', label: 'Force Directed', description: 'Physics-based layout' },
+    { value: 'CIRCULAR', label: 'Circular', description: 'Circular arrangement' },
+    { value: 'DAGRE', label: 'Dagre', description: 'Directed acyclic graph' },
+    { value: 'GRID', label: 'Grid', description: 'Grid-based layout' },
+    { value: 'CUSTOM', label: 'Custom', description: 'Custom positioning' }
+  ],
+
+  // Impact Levels
+  IMPACT_LEVELS: [
+    { value: 'MINIMAL', label: 'Minimal', color: 'green', score: 1 },
+    { value: 'LOW', label: 'Low', color: 'blue', score: 2 },
+    { value: 'MEDIUM', label: 'Medium', color: 'yellow', score: 3 },
+    { value: 'HIGH', label: 'High', color: 'orange', score: 4 },
+    { value: 'CRITICAL', label: 'Critical', color: 'red', score: 5 }
+  ]
+} as const;
+
+// ============================================================================
+// SEARCH CONSTANTS
+// ============================================================================
+
+export const SEARCH_CONSTANTS = {
+  // Search Types
+  SEARCH_TYPES: [
+    { value: 'KEYWORD', label: 'Keyword', description: 'Traditional keyword search' },
+    { value: 'SEMANTIC', label: 'Semantic', description: 'AI-powered semantic search' },
+    { value: 'NATURAL_LANGUAGE', label: 'Natural Language', description: 'Natural language queries' },
+    { value: 'FACETED', label: 'Faceted', description: 'Filtered faceted search' },
+    { value: 'FUZZY', label: 'Fuzzy', description: 'Fuzzy matching search' },
+    { value: 'BOOLEAN', label: 'Boolean', description: 'Boolean logic search' },
+    { value: 'PHRASE', label: 'Phrase', description: 'Exact phrase matching' },
+    { value: 'WILDCARD', label: 'Wildcard', description: 'Wildcard pattern search' }
+  ],
+
+  // Search Scopes
+  SEARCH_SCOPES: [
+    { value: 'ALL', label: 'All', description: 'Search everything' },
+    { value: 'ASSETS', label: 'Assets', description: 'Data assets only' },
+    { value: 'GLOSSARY', label: 'Glossary', description: 'Business glossary terms' },
+    { value: 'LINEAGE', label: 'Lineage', description: 'Data lineage information' },
+    { value: 'QUALITY', label: 'Quality', description: 'Quality information' },
+    { value: 'DOCUMENTATION', label: 'Documentation', description: 'Documentation content' }
+  ],
+
+  // Sort Options
+  SORT_OPTIONS: [
+    { value: 'RELEVANCE', label: 'Relevance', field: '_score' },
+    { value: 'POPULARITY', label: 'Popularity', field: 'popularityScore' },
+    { value: 'RECENCY', label: 'Most Recent', field: 'updatedAt' },
+    { value: 'ALPHABETICAL', label: 'Alphabetical', field: 'name' },
+    { value: 'QUALITY', label: 'Quality Score', field: 'qualityScore' },
+    { value: 'USAGE', label: 'Usage Count', field: 'usageCount' }
+  ],
+
+  // Filter Operators
+  FILTER_OPERATORS: [
+    { value: 'EQUALS', label: 'Equals', symbol: '=' },
+    { value: 'NOT_EQUALS', label: 'Not Equals', symbol: '!=' },
+    { value: 'CONTAINS', label: 'Contains', symbol: '~' },
+    { value: 'NOT_CONTAINS', label: 'Not Contains', symbol: '!~' },
+    { value: 'STARTS_WITH', label: 'Starts With', symbol: '^' },
+    { value: 'ENDS_WITH', label: 'Ends With', symbol: '$' },
+    { value: 'GREATER_THAN', label: 'Greater Than', symbol: '>' },
+    { value: 'LESS_THAN', label: 'Less Than', symbol: '<' },
+    { value: 'BETWEEN', label: 'Between', symbol: '<>' },
+    { value: 'IN', label: 'In', symbol: 'in' },
+    { value: 'NOT_IN', label: 'Not In', symbol: 'not in' }
+  ]
+} as const;
+
+// ============================================================================
+// ANALYTICS CONSTANTS
+// ============================================================================
+
+export const ANALYTICS_CONSTANTS = {
+  // Time Periods
+  TIME_PERIODS: [
+    { value: 'HOUR', label: 'Last Hour', days: 0, hours: 1 },
+    { value: 'DAY', label: 'Last 24 Hours', days: 1 },
+    { value: 'WEEK', label: 'Last Week', days: 7 },
+    { value: 'MONTH', label: 'Last Month', days: 30 },
+    { value: 'QUARTER', label: 'Last Quarter', days: 90 },
+    { value: 'YEAR', label: 'Last Year', days: 365 },
+    { value: 'CUSTOM', label: 'Custom Range', days: 0 }
+  ],
+
+  // Metric Categories
+  METRIC_CATEGORIES: [
+    { value: 'USAGE', label: 'Usage', icon: 'activity', description: 'Usage analytics' },
+    { value: 'PERFORMANCE', label: 'Performance', icon: 'zap', description: 'Performance metrics' },
+    { value: 'QUALITY', label: 'Quality', icon: 'shield', description: 'Data quality metrics' },
+    { value: 'BUSINESS', label: 'Business', icon: 'trending-up', description: 'Business value metrics' },
+    { value: 'TECHNICAL', label: 'Technical', icon: 'cpu', description: 'Technical metrics' },
+    { value: 'COMPLIANCE', label: 'Compliance', icon: 'check-circle', description: 'Compliance metrics' }
+  ],
+
+  // Chart Types
+  CHART_TYPES: [
+    { value: 'LINE', label: 'Line Chart', icon: 'trending-up', description: 'Time series data' },
+    { value: 'BAR', label: 'Bar Chart', icon: 'bar-chart', description: 'Categorical comparison' },
+    { value: 'PIE', label: 'Pie Chart', icon: 'pie-chart', description: 'Proportional data' },
+    { value: 'AREA', label: 'Area Chart', icon: 'activity', description: 'Cumulative data' },
+    { value: 'SCATTER', label: 'Scatter Plot', icon: 'circle', description: 'Correlation analysis' },
+    { value: 'HEATMAP', label: 'Heatmap', icon: 'grid', description: 'Matrix visualization' },
+    { value: 'GAUGE', label: 'Gauge', icon: 'gauge', description: 'Single metric' },
+    { value: 'TABLE', label: 'Table', icon: 'table', description: 'Tabular data' }
+  ],
+
+  // Aggregation Types
+  AGGREGATION_TYPES: [
+    { value: 'SUM', label: 'Sum', description: 'Total sum' },
+    { value: 'AVERAGE', label: 'Average', description: 'Mean value' },
+    { value: 'COUNT', label: 'Count', description: 'Count of items' },
+    { value: 'MIN', label: 'Minimum', description: 'Minimum value' },
+    { value: 'MAX', label: 'Maximum', description: 'Maximum value' },
+    { value: 'MEDIAN', label: 'Median', description: 'Middle value' },
+    { value: 'PERCENTILE', label: 'Percentile', description: 'Percentile value' },
+    { value: 'DISTINCT', label: 'Distinct', description: 'Unique count' }
+  ]
+} as const;
+
+// ============================================================================
+// DISCOVERY CONSTANTS
+// ============================================================================
+
+export const DISCOVERY_CONSTANTS = {
+  // Discovery Sources
+  SOURCE_TYPES: [
+    { value: 'DATABASE', label: 'Database', icon: 'database', description: 'Database systems' },
+    { value: 'FILE_SYSTEM', label: 'File System', icon: 'folder', description: 'File system sources' },
+    { value: 'CLOUD_STORAGE', label: 'Cloud Storage', icon: 'cloud', description: 'Cloud storage services' },
+    { value: 'API', label: 'API', icon: 'globe', description: 'REST/GraphQL APIs' },
+    { value: 'STREAMING', label: 'Streaming', icon: 'zap', description: 'Streaming data sources' },
+    { value: 'DATA_WAREHOUSE', label: 'Data Warehouse', icon: 'layers', description: 'Data warehouse systems' },
+    { value: 'DATA_LAKE', label: 'Data Lake', icon: 'database', description: 'Data lake storage' },
+    { value: 'NOSQL', label: 'NoSQL', icon: 'hard-drive', description: 'NoSQL databases' }
+  ],
+
+  // Discovery Phases
+  DISCOVERY_PHASES: [
+    { value: 'INITIALIZATION', label: 'Initialization', description: 'Setting up discovery job' },
+    { value: 'SCHEMA_DISCOVERY', label: 'Schema Discovery', description: 'Discovering data schemas' },
+    { value: 'DATA_PROFILING', label: 'Data Profiling', description: 'Profiling data content' },
+    { value: 'CLASSIFICATION', label: 'Classification', description: 'Classifying data types' },
+    { value: 'LINEAGE_DISCOVERY', label: 'Lineage Discovery', description: 'Discovering data lineage' },
+    { value: 'QUALITY_ASSESSMENT', label: 'Quality Assessment', description: 'Assessing data quality' },
+    { value: 'METADATA_ENRICHMENT', label: 'Metadata Enrichment', description: 'Enriching metadata' },
+    { value: 'FINALIZATION', label: 'Finalization', description: 'Finalizing discovery results' }
+  ],
+
+  // Discovery Priorities
+  PRIORITIES: [
+    { value: 'LOW', label: 'Low', color: 'blue', weight: 1 },
+    { value: 'MEDIUM', label: 'Medium', color: 'yellow', weight: 2 },
+    { value: 'HIGH', label: 'High', color: 'orange', weight: 3 },
+    { value: 'URGENT', label: 'Urgent', color: 'red', weight: 4 }
+  ],
+
+  // Discovery Methods
+  DISCOVERY_METHODS: [
+    { value: 'SCHEMA_ANALYSIS', label: 'Schema Analysis', description: 'Analyze database schemas' },
+    { value: 'DATA_SAMPLING', label: 'Data Sampling', description: 'Sample data content' },
+    { value: 'PATTERN_MATCHING', label: 'Pattern Matching', description: 'Match data patterns' },
+    { value: 'ML_CLASSIFICATION', label: 'ML Classification', description: 'Machine learning classification' },
+    { value: 'RULE_BASED', label: 'Rule Based', description: 'Rule-based discovery' },
+    { value: 'METADATA_INSPECTION', label: 'Metadata Inspection', description: 'Inspect existing metadata' },
+    { value: 'LINEAGE_TRACING', label: 'Lineage Tracing', description: 'Trace data lineage' }
+  ]
+} as const;
+
+// ============================================================================
+// UI CONSTANTS
+// ============================================================================
+
+export const UI_CONSTANTS = {
+  // Theme Colors
+  COLORS: {
+    PRIMARY: '#0066cc',
+    SECONDARY: '#6c757d',
+    SUCCESS: '#28a745',
+    WARNING: '#ffc107',
+    DANGER: '#dc3545',
+    INFO: '#17a2b8',
+    LIGHT: '#f8f9fa',
+    DARK: '#343a40'
+  },
+
+  // Status Colors
+  STATUS_COLORS: {
+    ACTIVE: '#28a745',
+    INACTIVE: '#6c757d',
+    DEPRECATED: '#ffc107',
+    DRAFT: '#17a2b8',
+    ARCHIVED: '#dc3545',
+    UNDER_REVIEW: '#fd7e14'
+  },
+
+  // Quality Colors
+  QUALITY_COLORS: {
+    EXCELLENT: '#28a745',
+    GOOD: '#7cb342',
+    FAIR: '#ffc107',
+    POOR: '#ff9800',
+    CRITICAL: '#dc3545'
+  },
+
+  // Icon Sizes
+  ICON_SIZES: {
+    XS: 12,
+    SM: 16,
+    MD: 20,
+    LG: 24,
+    XL: 32
+  },
+
+  // Border Radius
+  BORDER_RADIUS: {
+    SM: '0.25rem',
+    MD: '0.375rem',
+    LG: '0.5rem',
+    XL: '0.75rem',
+    FULL: '9999px'
+  },
+
+  // Spacing
+  SPACING: {
+    XS: '0.25rem',
+    SM: '0.5rem',
+    MD: '1rem',
+    LG: '1.5rem',
+    XL: '3rem'
+  },
+
+  // Z-Index
+  Z_INDEX: {
+    DROPDOWN: 1000,
+    STICKY: 1020,
+    FIXED: 1030,
+    MODAL_BACKDROP: 1040,
+    MODAL: 1050,
+    POPOVER: 1060,
+    TOOLTIP: 1070
+  }
+} as const;
+
+// ============================================================================
+// NOTIFICATION CONSTANTS
+// ============================================================================
+
+export const NOTIFICATION_CONSTANTS = {
+  // Notification Types
+  TYPES: [
+    { value: 'SUCCESS', label: 'Success', icon: 'check-circle', color: 'green' },
+    { value: 'INFO', label: 'Information', icon: 'info', color: 'blue' },
+    { value: 'WARNING', label: 'Warning', icon: 'alert-triangle', color: 'yellow' },
+    { value: 'ERROR', label: 'Error', icon: 'x-circle', color: 'red' }
+  ],
+
+  // Notification Positions
+  POSITIONS: [
+    { value: 'TOP_RIGHT', label: 'Top Right' },
+    { value: 'TOP_LEFT', label: 'Top Left' },
+    { value: 'TOP_CENTER', label: 'Top Center' },
+    { value: 'BOTTOM_RIGHT', label: 'Bottom Right' },
+    { value: 'BOTTOM_LEFT', label: 'Bottom Left' },
+    { value: 'BOTTOM_CENTER', label: 'Bottom Center' }
+  ],
+
+  // Auto Dismiss Times (in milliseconds)
+  AUTO_DISMISS: {
+    SUCCESS: 3000,
+    INFO: 5000,
+    WARNING: 8000,
+    ERROR: 0 // No auto dismiss for errors
+  }
+} as const;
+
+// ============================================================================
+// ERROR CONSTANTS
+// ============================================================================
+
+export const ERROR_CONSTANTS = {
+  // Error Categories
+  CATEGORIES: {
+    NETWORK: 'NETWORK',
+    VALIDATION: 'VALIDATION',
+    AUTHENTICATION: 'AUTHENTICATION',
+    AUTHORIZATION: 'AUTHORIZATION',
+    NOT_FOUND: 'NOT_FOUND',
+    SERVER_ERROR: 'SERVER_ERROR',
+    CLIENT_ERROR: 'CLIENT_ERROR',
+    TIMEOUT: 'TIMEOUT',
+    UNKNOWN: 'UNKNOWN'
+  },
+
+  // HTTP Status Codes
+  HTTP_STATUS: {
+    OK: 200,
+    CREATED: 201,
+    NO_CONTENT: 204,
+    BAD_REQUEST: 400,
+    UNAUTHORIZED: 401,
+    FORBIDDEN: 403,
+    NOT_FOUND: 404,
+    METHOD_NOT_ALLOWED: 405,
+    CONFLICT: 409,
+    UNPROCESSABLE_ENTITY: 422,
+    TOO_MANY_REQUESTS: 429,
+    INTERNAL_SERVER_ERROR: 500,
+    BAD_GATEWAY: 502,
+    SERVICE_UNAVAILABLE: 503,
+    GATEWAY_TIMEOUT: 504
+  },
+
+  // Error Messages
+  MESSAGES: {
+    NETWORK_ERROR: 'Network connection error. Please check your internet connection.',
+    TIMEOUT_ERROR: 'Request timed out. Please try again.',
+    UNAUTHORIZED: 'You are not authorized to perform this action.',
+    FORBIDDEN: 'Access to this resource is forbidden.',
+    NOT_FOUND: 'The requested resource was not found.',
+    SERVER_ERROR: 'An internal server error occurred. Please try again later.',
+    VALIDATION_ERROR: 'Please check your input and try again.',
+    UNKNOWN_ERROR: 'An unexpected error occurred. Please try again.'
+  }
+} as const;
+
+// ============================================================================
+// EXPORT ALL CONSTANTS
+// ============================================================================
+
+export const ALL_CONSTANTS = {
+  CATALOG_CONFIG,
+  ASSET_CONSTANTS,
+  QUALITY_CONSTANTS,
+  LINEAGE_CONSTANTS,
+  SEARCH_CONSTANTS,
+  ANALYTICS_CONSTANTS,
+  DISCOVERY_CONSTANTS,
+  UI_CONSTANTS,
+  NOTIFICATION_CONSTANTS,
+  ERROR_CONSTANTS
+} as const;
+
+export default ALL_CONSTANTS;

--- a/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-endpoints.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-endpoints.ts
@@ -1,0 +1,774 @@
+// ============================================================================
+// ADVANCED CATALOG API ENDPOINTS - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// API endpoint constants mapping to backend routes from CORRECTED_BACKEND_MAPPING_CATALOG.md
+// ============================================================================
+
+// ============================================================================
+// BASE API CONFIGURATION
+// ============================================================================
+
+export const API_CONFIG = {
+  BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000',
+  VERSION: 'v1',
+  TIMEOUT: 30000,
+  RETRY_ATTEMPTS: 3,
+  RETRY_DELAY: 1000
+} as const;
+
+// Construct base API URL
+export const API_BASE = `${API_CONFIG.BASE_URL}/api/${API_CONFIG.VERSION}`;
+
+// ============================================================================
+// ENTERPRISE CATALOG ENDPOINTS (enterprise_catalog_routes.py)
+// ============================================================================
+
+export const ENTERPRISE_CATALOG_ENDPOINTS = {
+  // Asset Management
+  ASSETS: {
+    LIST: `${API_BASE}/catalog/assets`,
+    CREATE: `${API_BASE}/catalog/assets`,
+    GET: (id: string) => `${API_BASE}/catalog/assets/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/catalog/assets/${id}`,
+    DELETE: (id: string) => `${API_BASE}/catalog/assets/${id}`,
+    BULK_UPDATE: `${API_BASE}/catalog/assets/bulk`,
+    BULK_DELETE: `${API_BASE}/catalog/assets/bulk/delete`,
+    EXPORT: `${API_BASE}/catalog/assets/export`,
+    IMPORT: `${API_BASE}/catalog/assets/import`,
+    VALIDATE: `${API_BASE}/catalog/assets/validate`,
+    SCHEMA: (id: string) => `${API_BASE}/catalog/assets/${id}/schema`,
+    COLUMNS: (id: string) => `${API_BASE}/catalog/assets/${id}/columns`,
+    METADATA: (id: string) => `${API_BASE}/catalog/assets/${id}/metadata`,
+    RELATIONSHIPS: (id: string) => `${API_BASE}/catalog/assets/${id}/relationships`,
+    TAGS: (id: string) => `${API_BASE}/catalog/assets/${id}/tags`,
+    CLASSIFICATIONS: (id: string) => `${API_BASE}/catalog/assets/${id}/classifications`,
+    QUALITY_SCORE: (id: string) => `${API_BASE}/catalog/assets/${id}/quality`,
+    USAGE_METRICS: (id: string) => `${API_BASE}/catalog/assets/${id}/usage`,
+    LINEAGE: (id: string) => `${API_BASE}/catalog/assets/${id}/lineage`,
+    RECOMMENDATIONS: (id: string) => `${API_BASE}/catalog/assets/${id}/recommendations`,
+    SIMILAR: (id: string) => `${API_BASE}/catalog/assets/${id}/similar`,
+    FAVORITES: (id: string) => `${API_BASE}/catalog/assets/${id}/favorites`,
+    WATCH: (id: string) => `${API_BASE}/catalog/assets/${id}/watch`,
+    COMMENTS: (id: string) => `${API_BASE}/catalog/assets/${id}/comments`,
+    RATINGS: (id: string) => `${API_BASE}/catalog/assets/${id}/ratings`,
+    VERSIONS: (id: string) => `${API_BASE}/catalog/assets/${id}/versions`,
+    CLONE: (id: string) => `${API_BASE}/catalog/assets/${id}/clone`
+  },
+
+  // Enterprise Features
+  ENTERPRISE: {
+    DASHBOARD: `${API_BASE}/catalog/enterprise/dashboard`,
+    HEALTH: `${API_BASE}/catalog/enterprise/health`,
+    METRICS: `${API_BASE}/catalog/enterprise/metrics`,
+    REPORTS: `${API_BASE}/catalog/enterprise/reports`,
+    AUDIT: `${API_BASE}/catalog/enterprise/audit`,
+    GOVERNANCE: `${API_BASE}/catalog/enterprise/governance`,
+    COMPLIANCE: `${API_BASE}/catalog/enterprise/compliance`,
+    SECURITY: `${API_BASE}/catalog/enterprise/security`,
+    PERFORMANCE: `${API_BASE}/catalog/enterprise/performance`,
+    CONFIGURATION: `${API_BASE}/catalog/enterprise/configuration`,
+    BACKUP: `${API_BASE}/catalog/enterprise/backup`,
+    RESTORE: `${API_BASE}/catalog/enterprise/restore`,
+    MIGRATION: `${API_BASE}/catalog/enterprise/migration`,
+    INTEGRATION: `${API_BASE}/catalog/enterprise/integration`
+  },
+
+  // Catalog Management
+  CATALOG: {
+    OVERVIEW: `${API_BASE}/catalog/overview`,
+    STATISTICS: `${API_BASE}/catalog/statistics`,
+    CATEGORIES: `${API_BASE}/catalog/categories`,
+    COLLECTIONS: `${API_BASE}/catalog/collections`,
+    BOOKMARKS: `${API_BASE}/catalog/bookmarks`,
+    RECENT: `${API_BASE}/catalog/recent`,
+    TRENDING: `${API_BASE}/catalog/trending`,
+    POPULAR: `${API_BASE}/catalog/popular`,
+    FEATURED: `${API_BASE}/catalog/featured`,
+    RECOMMENDATIONS: `${API_BASE}/catalog/recommendations`,
+    PERSONALIZED: `${API_BASE}/catalog/personalized`
+  }
+} as const;
+
+// ============================================================================
+// INTELLIGENT DISCOVERY ENDPOINTS (intelligent_discovery_routes.py)
+// ============================================================================
+
+export const DISCOVERY_ENDPOINTS = {
+  // Discovery Jobs
+  JOBS: {
+    LIST: `${API_BASE}/discovery/jobs`,
+    CREATE: `${API_BASE}/discovery/jobs`,
+    GET: (id: string) => `${API_BASE}/discovery/jobs/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/discovery/jobs/${id}`,
+    DELETE: (id: string) => `${API_BASE}/discovery/jobs/${id}`,
+    START: (id: string) => `${API_BASE}/discovery/jobs/${id}/start`,
+    STOP: (id: string) => `${API_BASE}/discovery/jobs/${id}/stop`,
+    PAUSE: (id: string) => `${API_BASE}/discovery/jobs/${id}/pause`,
+    RESUME: (id: string) => `${API_BASE}/discovery/jobs/${id}/resume`,
+    STATUS: (id: string) => `${API_BASE}/discovery/jobs/${id}/status`,
+    PROGRESS: (id: string) => `${API_BASE}/discovery/jobs/${id}/progress`,
+    RESULTS: (id: string) => `${API_BASE}/discovery/jobs/${id}/results`,
+    LOGS: (id: string) => `${API_BASE}/discovery/jobs/${id}/logs`,
+    CANCEL: (id: string) => `${API_BASE}/discovery/jobs/${id}/cancel`,
+    RETRY: (id: string) => `${API_BASE}/discovery/jobs/${id}/retry`,
+    CLONE: (id: string) => `${API_BASE}/discovery/jobs/${id}/clone`,
+    EXPORT: (id: string) => `${API_BASE}/discovery/jobs/${id}/export`
+  },
+
+  // Discovery Configuration
+  CONFIGURATIONS: {
+    LIST: `${API_BASE}/discovery/configurations`,
+    CREATE: `${API_BASE}/discovery/configurations`,
+    GET: (id: string) => `${API_BASE}/discovery/configurations/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/discovery/configurations/${id}`,
+    DELETE: (id: string) => `${API_BASE}/discovery/configurations/${id}`,
+    VALIDATE: `${API_BASE}/discovery/configurations/validate`,
+    TEMPLATES: `${API_BASE}/discovery/configurations/templates`,
+    DUPLICATE: (id: string) => `${API_BASE}/discovery/configurations/${id}/duplicate`,
+    TEST: (id: string) => `${API_BASE}/discovery/configurations/${id}/test`
+  },
+
+  // Discovery Sources
+  SOURCES: {
+    LIST: `${API_BASE}/discovery/sources`,
+    CREATE: `${API_BASE}/discovery/sources`,
+    GET: (id: string) => `${API_BASE}/discovery/sources/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/discovery/sources/${id}`,
+    DELETE: (id: string) => `${API_BASE}/discovery/sources/${id}`,
+    TEST_CONNECTION: (id: string) => `${API_BASE}/discovery/sources/${id}/test`,
+    SCAN: (id: string) => `${API_BASE}/discovery/sources/${id}/scan`,
+    PREVIEW: (id: string) => `${API_BASE}/discovery/sources/${id}/preview`,
+    SCHEMA: (id: string) => `${API_BASE}/discovery/sources/${id}/schema`,
+    STATISTICS: (id: string) => `${API_BASE}/discovery/sources/${id}/statistics`
+  },
+
+  // Incremental Discovery
+  INCREMENTAL: {
+    LIST: `${API_BASE}/discovery/incremental`,
+    CREATE: `${API_BASE}/discovery/incremental`,
+    GET: (id: string) => `${API_BASE}/discovery/incremental/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/discovery/incremental/${id}`,
+    DELETE: (id: string) => `${API_BASE}/discovery/incremental/${id}`,
+    CHANGES: (id: string) => `${API_BASE}/discovery/incremental/${id}/changes`,
+    SYNC: (id: string) => `${API_BASE}/discovery/incremental/${id}/sync`,
+    BASELINE: (id: string) => `${API_BASE}/discovery/incremental/${id}/baseline`
+  },
+
+  // Discovery Analytics
+  ANALYTICS: {
+    OVERVIEW: `${API_BASE}/discovery/analytics/overview`,
+    PERFORMANCE: `${API_BASE}/discovery/analytics/performance`,
+    TRENDS: `${API_BASE}/discovery/analytics/trends`,
+    SUCCESS_RATE: `${API_BASE}/discovery/analytics/success-rate`,
+    ERROR_ANALYSIS: `${API_BASE}/discovery/analytics/errors`,
+    RECOMMENDATIONS: `${API_BASE}/discovery/analytics/recommendations`
+  }
+} as const;
+
+// ============================================================================
+// SEMANTIC SEARCH ENDPOINTS (semantic_search_routes.py)
+// ============================================================================
+
+export const SEARCH_ENDPOINTS = {
+  // Search Operations
+  SEARCH: {
+    QUERY: `${API_BASE}/search`,
+    SEMANTIC: `${API_BASE}/search/semantic`,
+    ADVANCED: `${API_BASE}/search/advanced`,
+    FACETED: `${API_BASE}/search/faceted`,
+    NATURAL_LANGUAGE: `${API_BASE}/search/nl`,
+    SIMILARITY: `${API_BASE}/search/similarity`,
+    FUZZY: `${API_BASE}/search/fuzzy`,
+    BOOLEAN: `${API_BASE}/search/boolean`,
+    SUGGEST: `${API_BASE}/search/suggest`,
+    AUTOCOMPLETE: `${API_BASE}/search/autocomplete`,
+    CORRECTIONS: `${API_BASE}/search/corrections`,
+    RELATED: `${API_BASE}/search/related`,
+    TRENDING: `${API_BASE}/search/trending`,
+    POPULAR: `${API_BASE}/search/popular`,
+    RECENT: `${API_BASE}/search/recent`,
+    SAVED: `${API_BASE}/search/saved`,
+    EXPORT: `${API_BASE}/search/export`
+  },
+
+  // Search Configuration
+  CONFIGURATION: {
+    GET: `${API_BASE}/search/configuration`,
+    UPDATE: `${API_BASE}/search/configuration`,
+    RESET: `${API_BASE}/search/configuration/reset`,
+    VALIDATE: `${API_BASE}/search/configuration/validate`,
+    BACKUP: `${API_BASE}/search/configuration/backup`,
+    RESTORE: `${API_BASE}/search/configuration/restore`
+  },
+
+  // Search Index Management
+  INDEX: {
+    STATUS: `${API_BASE}/search/index/status`,
+    REBUILD: `${API_BASE}/search/index/rebuild`,
+    OPTIMIZE: `${API_BASE}/search/index/optimize`,
+    STATISTICS: `${API_BASE}/search/index/statistics`,
+    HEALTH: `${API_BASE}/search/index/health`,
+    SETTINGS: `${API_BASE}/search/index/settings`,
+    MAPPINGS: `${API_BASE}/search/index/mappings`,
+    ALIASES: `${API_BASE}/search/index/aliases`
+  },
+
+  // Search Analytics
+  ANALYTICS: {
+    OVERVIEW: `${API_BASE}/search/analytics/overview`,
+    QUERIES: `${API_BASE}/search/analytics/queries`,
+    PERFORMANCE: `${API_BASE}/search/analytics/performance`,
+    USER_BEHAVIOR: `${API_BASE}/search/analytics/behavior`,
+    CLICK_THROUGH: `${API_BASE}/search/analytics/clicks`,
+    CONVERSION: `${API_BASE}/search/analytics/conversion`,
+    A_B_TESTS: `${API_BASE}/search/analytics/ab-tests`,
+    RECOMMENDATIONS: `${API_BASE}/search/analytics/recommendations`
+  },
+
+  // Personalization
+  PERSONALIZATION: {
+    PROFILE: (userId: string) => `${API_BASE}/search/personalization/${userId}`,
+    PREFERENCES: (userId: string) => `${API_BASE}/search/personalization/${userId}/preferences`,
+    HISTORY: (userId: string) => `${API_BASE}/search/personalization/${userId}/history`,
+    RECOMMENDATIONS: (userId: string) => `${API_BASE}/search/personalization/${userId}/recommendations`,
+    FEEDBACK: (userId: string) => `${API_BASE}/search/personalization/${userId}/feedback`
+  }
+} as const;
+
+// ============================================================================
+// CATALOG QUALITY ENDPOINTS (catalog_quality_routes.py)
+// ============================================================================
+
+export const QUALITY_ENDPOINTS = {
+  // Quality Assessments
+  ASSESSMENTS: {
+    LIST: `${API_BASE}/quality/assessments`,
+    CREATE: `${API_BASE}/quality/assessments`,
+    GET: (id: string) => `${API_BASE}/quality/assessments/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/quality/assessments/${id}`,
+    DELETE: (id: string) => `${API_BASE}/quality/assessments/${id}`,
+    RUN: (id: string) => `${API_BASE}/quality/assessments/${id}/run`,
+    SCHEDULE: (id: string) => `${API_BASE}/quality/assessments/${id}/schedule`,
+    RESULTS: (id: string) => `${API_BASE}/quality/assessments/${id}/results`,
+    HISTORY: (id: string) => `${API_BASE}/quality/assessments/${id}/history`,
+    TRENDS: (id: string) => `${API_BASE}/quality/assessments/${id}/trends`,
+    EXPORT: (id: string) => `${API_BASE}/quality/assessments/${id}/export`
+  },
+
+  // Quality Rules
+  RULES: {
+    LIST: `${API_BASE}/quality/rules`,
+    CREATE: `${API_BASE}/quality/rules`,
+    GET: (id: string) => `${API_BASE}/quality/rules/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/quality/rules/${id}`,
+    DELETE: (id: string) => `${API_BASE}/quality/rules/${id}`,
+    VALIDATE: `${API_BASE}/quality/rules/validate`,
+    TEMPLATES: `${API_BASE}/quality/rules/templates`,
+    EXECUTE: (id: string) => `${API_BASE}/quality/rules/${id}/execute`,
+    TEST: (id: string) => `${API_BASE}/quality/rules/${id}/test`,
+    DUPLICATE: (id: string) => `${API_BASE}/quality/rules/${id}/duplicate`,
+    LIBRARY: `${API_BASE}/quality/rules/library`,
+    CATEGORIES: `${API_BASE}/quality/rules/categories`
+  },
+
+  // Quality Dashboard
+  DASHBOARD: {
+    OVERVIEW: `${API_BASE}/quality/dashboard`,
+    SCORECARD: `${API_BASE}/quality/dashboard/scorecard`,
+    TRENDS: `${API_BASE}/quality/dashboard/trends`,
+    ISSUES: `${API_BASE}/quality/dashboard/issues`,
+    ALERTS: `${API_BASE}/quality/dashboard/alerts`,
+    REPORTS: `${API_BASE}/quality/dashboard/reports`,
+    WIDGETS: `${API_BASE}/quality/dashboard/widgets`,
+    PERSONALIZE: `${API_BASE}/quality/dashboard/personalize`
+  },
+
+  // Quality Issues
+  ISSUES: {
+    LIST: `${API_BASE}/quality/issues`,
+    GET: (id: string) => `${API_BASE}/quality/issues/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/quality/issues/${id}`,
+    RESOLVE: (id: string) => `${API_BASE}/quality/issues/${id}/resolve`,
+    ASSIGN: (id: string) => `${API_BASE}/quality/issues/${id}/assign`,
+    COMMENT: (id: string) => `${API_BASE}/quality/issues/${id}/comments`,
+    TRACK: (id: string) => `${API_BASE}/quality/issues/${id}/track`,
+    BULK_UPDATE: `${API_BASE}/quality/issues/bulk`,
+    STATISTICS: `${API_BASE}/quality/issues/statistics`,
+    TRENDS: `${API_BASE}/quality/issues/trends`
+  },
+
+  // Quality Monitoring
+  MONITORING: {
+    LIST: `${API_BASE}/quality/monitoring`,
+    CREATE: `${API_BASE}/quality/monitoring`,
+    GET: (id: string) => `${API_BASE}/quality/monitoring/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/quality/monitoring/${id}`,
+    DELETE: (id: string) => `${API_BASE}/quality/monitoring/${id}`,
+    START: (id: string) => `${API_BASE}/quality/monitoring/${id}/start`,
+    STOP: (id: string) => `${API_BASE}/quality/monitoring/${id}/stop`,
+    STATUS: (id: string) => `${API_BASE}/quality/monitoring/${id}/status`,
+    ALERTS: (id: string) => `${API_BASE}/quality/monitoring/${id}/alerts`,
+    CONFIGURE: (id: string) => `${API_BASE}/quality/monitoring/${id}/configure`
+  },
+
+  // Quality Reports
+  REPORTS: {
+    LIST: `${API_BASE}/quality/reports`,
+    CREATE: `${API_BASE}/quality/reports`,
+    GET: (id: string) => `${API_BASE}/quality/reports/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/quality/reports/${id}`,
+    DELETE: (id: string) => `${API_BASE}/quality/reports/${id}`,
+    GENERATE: (id: string) => `${API_BASE}/quality/reports/${id}/generate`,
+    SCHEDULE: (id: string) => `${API_BASE}/quality/reports/${id}/schedule`,
+    EXPORT: (id: string) => `${API_BASE}/quality/reports/${id}/export`,
+    SHARE: (id: string) => `${API_BASE}/quality/reports/${id}/share`,
+    TEMPLATES: `${API_BASE}/quality/reports/templates`
+  }
+} as const;
+
+// ============================================================================
+// DATA PROFILING ENDPOINTS (data_profiling.py)
+// ============================================================================
+
+export const PROFILING_ENDPOINTS = {
+  // Profiling Jobs
+  JOBS: {
+    LIST: `${API_BASE}/profiling/jobs`,
+    CREATE: `${API_BASE}/profiling/jobs`,
+    GET: (id: string) => `${API_BASE}/profiling/jobs/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/profiling/jobs/${id}`,
+    DELETE: (id: string) => `${API_BASE}/profiling/jobs/${id}`,
+    START: (id: string) => `${API_BASE}/profiling/jobs/${id}/start`,
+    STOP: (id: string) => `${API_BASE}/profiling/jobs/${id}/stop`,
+    STATUS: (id: string) => `${API_BASE}/profiling/jobs/${id}/status`,
+    RESULTS: (id: string) => `${API_BASE}/profiling/jobs/${id}/results`,
+    STATISTICS: (id: string) => `${API_BASE}/profiling/jobs/${id}/statistics`,
+    EXPORT: (id: string) => `${API_BASE}/profiling/jobs/${id}/export`
+  },
+
+  // Profiling Results
+  RESULTS: {
+    LIST: `${API_BASE}/profiling/results`,
+    GET: (id: string) => `${API_BASE}/profiling/results/${id}`,
+    COMPARE: `${API_BASE}/profiling/results/compare`,
+    TRENDS: `${API_BASE}/profiling/results/trends`,
+    SUMMARY: `${API_BASE}/profiling/results/summary`,
+    ANOMALIES: `${API_BASE}/profiling/results/anomalies`,
+    PATTERNS: `${API_BASE}/profiling/results/patterns`,
+    EXPORT: `${API_BASE}/profiling/results/export`,
+    ARCHIVE: (id: string) => `${API_BASE}/profiling/results/${id}/archive`
+  },
+
+  // Column Profiling
+  COLUMNS: {
+    PROFILE: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/profile`,
+    STATISTICS: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/statistics`,
+    DISTRIBUTION: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/distribution`,
+    PATTERNS: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/patterns`,
+    ANOMALIES: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/anomalies`,
+    SAMPLES: (assetId: string, columnName: string) => 
+      `${API_BASE}/profiling/assets/${assetId}/columns/${columnName}/samples`
+  },
+
+  // Asset Profiling
+  ASSETS: {
+    PROFILE: (id: string) => `${API_BASE}/profiling/assets/${id}/profile`,
+    QUICK_PROFILE: (id: string) => `${API_BASE}/profiling/assets/${id}/quick-profile`,
+    FULL_PROFILE: (id: string) => `${API_BASE}/profiling/assets/${id}/full-profile`,
+    INCREMENTAL: (id: string) => `${API_BASE}/profiling/assets/${id}/incremental`,
+    SCHEDULE: (id: string) => `${API_BASE}/profiling/assets/${id}/schedule`,
+    HISTORY: (id: string) => `${API_BASE}/profiling/assets/${id}/history`
+  }
+} as const;
+
+// ============================================================================
+// ADVANCED LINEAGE ENDPOINTS (advanced_lineage_routes.py)
+// ============================================================================
+
+export const LINEAGE_ENDPOINTS = {
+  // Lineage Management
+  LINEAGE: {
+    LIST: `${API_BASE}/lineage`,
+    CREATE: `${API_BASE}/lineage`,
+    GET: (id: string) => `${API_BASE}/lineage/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/lineage/${id}`,
+    DELETE: (id: string) => `${API_BASE}/lineage/${id}`,
+    VALIDATE: `${API_BASE}/lineage/validate`,
+    BULK_CREATE: `${API_BASE}/lineage/bulk`,
+    BULK_UPDATE: `${API_BASE}/lineage/bulk/update`,
+    BULK_DELETE: `${API_BASE}/lineage/bulk/delete`,
+    EXPORT: `${API_BASE}/lineage/export`,
+    IMPORT: `${API_BASE}/lineage/import`
+  },
+
+  // Asset Lineage
+  ASSETS: {
+    UPSTREAM: (id: string) => `${API_BASE}/lineage/assets/${id}/upstream`,
+    DOWNSTREAM: (id: string) => `${API_BASE}/lineage/assets/${id}/downstream`,
+    FULL: (id: string) => `${API_BASE}/lineage/assets/${id}/full`,
+    COLUMN_LEVEL: (id: string) => `${API_BASE}/lineage/assets/${id}/column-level`,
+    IMPACT_ANALYSIS: (id: string) => `${API_BASE}/lineage/assets/${id}/impact`,
+    DEPENDENCIES: (id: string) => `${API_BASE}/lineage/assets/${id}/dependencies`,
+    RELATIONSHIPS: (id: string) => `${API_BASE}/lineage/assets/${id}/relationships`,
+    PATHS: (id: string) => `${API_BASE}/lineage/assets/${id}/paths`,
+    GRAPH: (id: string) => `${API_BASE}/lineage/assets/${id}/graph`,
+    VISUALIZATION: (id: string) => `${API_BASE}/lineage/assets/${id}/visualization`
+  },
+
+  // Lineage Discovery
+  DISCOVERY: {
+    JOBS: `${API_BASE}/lineage/discovery/jobs`,
+    CREATE_JOB: `${API_BASE}/lineage/discovery/jobs`,
+    GET_JOB: (id: string) => `${API_BASE}/lineage/discovery/jobs/${id}`,
+    START_JOB: (id: string) => `${API_BASE}/lineage/discovery/jobs/${id}/start`,
+    STOP_JOB: (id: string) => `${API_BASE}/lineage/discovery/jobs/${id}/stop`,
+    RESULTS: (id: string) => `${API_BASE}/lineage/discovery/jobs/${id}/results`,
+    AUTO_DISCOVER: `${API_BASE}/lineage/discovery/auto`,
+    MANUAL_CREATE: `${API_BASE}/lineage/discovery/manual`,
+    SUGGESTIONS: `${API_BASE}/lineage/discovery/suggestions`,
+    VALIDATE_DISCOVERY: `${API_BASE}/lineage/discovery/validate`
+  },
+
+  // Lineage Quality
+  QUALITY: {
+    ASSESS: `${API_BASE}/lineage/quality/assess`,
+    ISSUES: `${API_BASE}/lineage/quality/issues`,
+    VALIDATE: `${API_BASE}/lineage/quality/validate`,
+    SCORE: (id: string) => `${API_BASE}/lineage/quality/${id}/score`,
+    RECOMMENDATIONS: `${API_BASE}/lineage/quality/recommendations`,
+    RULES: `${API_BASE}/lineage/quality/rules`,
+    MONITORING: `${API_BASE}/lineage/quality/monitoring`
+  },
+
+  // Lineage Visualization
+  VISUALIZATION: {
+    GRAPH: `${API_BASE}/lineage/visualization/graph`,
+    HIERARCHICAL: `${API_BASE}/lineage/visualization/hierarchical`,
+    FORCE_DIRECTED: `${API_BASE}/lineage/visualization/force-directed`,
+    MATRIX: `${API_BASE}/lineage/visualization/matrix`,
+    SANKEY: `${API_BASE}/lineage/visualization/sankey`,
+    CUSTOM: `${API_BASE}/lineage/visualization/custom`,
+    EXPORT_SVG: `${API_BASE}/lineage/visualization/export/svg`,
+    EXPORT_PNG: `${API_BASE}/lineage/visualization/export/png`,
+    EXPORT_PDF: `${API_BASE}/lineage/visualization/export/pdf`
+  },
+
+  // Lineage Analytics
+  ANALYTICS: {
+    OVERVIEW: `${API_BASE}/lineage/analytics/overview`,
+    METRICS: `${API_BASE}/lineage/analytics/metrics`,
+    PATTERNS: `${API_BASE}/lineage/analytics/patterns`,
+    COMPLEXITY: `${API_BASE}/lineage/analytics/complexity`,
+    COVERAGE: `${API_BASE}/lineage/analytics/coverage`,
+    TRENDS: `${API_BASE}/lineage/analytics/trends`,
+    REPORTS: `${API_BASE}/lineage/analytics/reports`
+  }
+} as const;
+
+// ============================================================================
+// CATALOG ANALYTICS ENDPOINTS (catalog_analytics_routes.py)
+// ============================================================================
+
+export const ANALYTICS_ENDPOINTS = {
+  // General Analytics
+  OVERVIEW: `${API_BASE}/analytics/overview`,
+  DASHBOARD: `${API_BASE}/analytics/dashboard`,
+  METRICS: `${API_BASE}/analytics/metrics`,
+  KPI: `${API_BASE}/analytics/kpi`,
+  TRENDS: `${API_BASE}/analytics/trends`,
+  INSIGHTS: `${API_BASE}/analytics/insights`,
+  REPORTS: `${API_BASE}/analytics/reports`,
+  EXPORT: `${API_BASE}/analytics/export`,
+
+  // Usage Analytics
+  USAGE: {
+    OVERVIEW: `${API_BASE}/analytics/usage/overview`,
+    ASSETS: `${API_BASE}/analytics/usage/assets`,
+    USERS: `${API_BASE}/analytics/usage/users`,
+    PATTERNS: `${API_BASE}/analytics/usage/patterns`,
+    TRENDS: `${API_BASE}/analytics/usage/trends`,
+    POPULAR: `${API_BASE}/analytics/usage/popular`,
+    ENGAGEMENT: `${API_BASE}/analytics/usage/engagement`,
+    SESSIONS: `${API_BASE}/analytics/usage/sessions`,
+    GEOGRAPHY: `${API_BASE}/analytics/usage/geography`,
+    DEVICES: `${API_BASE}/analytics/usage/devices`,
+    REFERRERS: `${API_BASE}/analytics/usage/referrers`
+  },
+
+  // Business Analytics
+  BUSINESS: {
+    VALUE: `${API_BASE}/analytics/business/value`,
+    ROI: `${API_BASE}/analytics/business/roi`,
+    COST_BENEFIT: `${API_BASE}/analytics/business/cost-benefit`,
+    EFFICIENCY: `${API_BASE}/analytics/business/efficiency`,
+    PRODUCTIVITY: `${API_BASE}/analytics/business/productivity`,
+    COMPLIANCE: `${API_BASE}/analytics/business/compliance`,
+    RISK: `${API_BASE}/analytics/business/risk`,
+    STRATEGIC: `${API_BASE}/analytics/business/strategic`
+  },
+
+  // Technical Analytics
+  TECHNICAL: {
+    PERFORMANCE: `${API_BASE}/analytics/technical/performance`,
+    AVAILABILITY: `${API_BASE}/analytics/technical/availability`,
+    RELIABILITY: `${API_BASE}/analytics/technical/reliability`,
+    SCALABILITY: `${API_BASE}/analytics/technical/scalability`,
+    SECURITY: `${API_BASE}/analytics/technical/security`,
+    INTEGRATION: `${API_BASE}/analytics/technical/integration`,
+    ERRORS: `${API_BASE}/analytics/technical/errors`,
+    CAPACITY: `${API_BASE}/analytics/technical/capacity`
+  },
+
+  // Predictive Analytics
+  PREDICTIVE: {
+    MODELS: `${API_BASE}/analytics/predictive/models`,
+    FORECASTS: `${API_BASE}/analytics/predictive/forecasts`,
+    PREDICTIONS: `${API_BASE}/analytics/predictive/predictions`,
+    SCENARIOS: `${API_BASE}/analytics/predictive/scenarios`,
+    RECOMMENDATIONS: `${API_BASE}/analytics/predictive/recommendations`,
+    TRAINING: `${API_BASE}/analytics/predictive/training`,
+    VALIDATION: `${API_BASE}/analytics/predictive/validation`,
+    DEPLOYMENT: `${API_BASE}/analytics/predictive/deployment`
+  }
+} as const;
+
+// ============================================================================
+// ENTERPRISE ANALYTICS ENDPOINTS (enterprise_analytics.py)
+// ============================================================================
+
+export const ENTERPRISE_ANALYTICS_ENDPOINTS = {
+  // Cross-System Analytics
+  CROSS_SYSTEM: {
+    OVERVIEW: `${API_BASE}/enterprise/analytics/cross-system/overview`,
+    METRICS: `${API_BASE}/enterprise/analytics/cross-system/metrics`,
+    INTEGRATION: `${API_BASE}/enterprise/analytics/cross-system/integration`,
+    DATA_FLOW: `${API_BASE}/enterprise/analytics/cross-system/data-flow`,
+    DEPENDENCIES: `${API_BASE}/enterprise/analytics/cross-system/dependencies`,
+    HEALTH: `${API_BASE}/enterprise/analytics/cross-system/health`,
+    PERFORMANCE: `${API_BASE}/enterprise/analytics/cross-system/performance`
+  },
+
+  // Enterprise Metrics
+  ENTERPRISE: {
+    DASHBOARD: `${API_BASE}/enterprise/analytics/dashboard`,
+    SCORECARD: `${API_BASE}/enterprise/analytics/scorecard`,
+    KPI: `${API_BASE}/enterprise/analytics/kpi`,
+    BENCHMARKS: `${API_BASE}/enterprise/analytics/benchmarks`,
+    COMPARISON: `${API_BASE}/enterprise/analytics/comparison`,
+    MATURITY: `${API_BASE}/enterprise/analytics/maturity`,
+    GOVERNANCE: `${API_BASE}/enterprise/analytics/governance`,
+    COMPLIANCE: `${API_BASE}/enterprise/analytics/compliance`
+  },
+
+  // Advanced Analytics
+  ADVANCED: {
+    AI_INSIGHTS: `${API_BASE}/enterprise/analytics/ai/insights`,
+    ML_MODELS: `${API_BASE}/enterprise/analytics/ml/models`,
+    ANOMALY_DETECTION: `${API_BASE}/enterprise/analytics/anomaly-detection`,
+    PATTERN_RECOGNITION: `${API_BASE}/enterprise/analytics/pattern-recognition`,
+    CORRELATION_ANALYSIS: `${API_BASE}/enterprise/analytics/correlation`,
+    CAUSAL_ANALYSIS: `${API_BASE}/enterprise/analytics/causal`,
+    OPTIMIZATION: `${API_BASE}/enterprise/analytics/optimization`,
+    SIMULATION: `${API_BASE}/enterprise/analytics/simulation`
+  },
+
+  // Real-time Analytics
+  REAL_TIME: {
+    STREAMING: `${API_BASE}/enterprise/analytics/real-time/streaming`,
+    EVENTS: `${API_BASE}/enterprise/analytics/real-time/events`,
+    ALERTS: `${API_BASE}/enterprise/analytics/real-time/alerts`,
+    MONITORING: `${API_BASE}/enterprise/analytics/real-time/monitoring`,
+    DASHBOARDS: `${API_BASE}/enterprise/analytics/real-time/dashboards`,
+    NOTIFICATIONS: `${API_BASE}/enterprise/analytics/real-time/notifications`
+  }
+} as const;
+
+// ============================================================================
+// DATA DISCOVERY ENDPOINTS (data_discovery_routes.py)
+// ============================================================================
+
+export const DATA_DISCOVERY_ENDPOINTS = {
+  // Asset Discovery
+  ASSETS: {
+    DISCOVER: `${API_BASE}/data-discovery/assets/discover`,
+    EXPLORE: `${API_BASE}/data-discovery/assets/explore`,
+    BROWSE: `${API_BASE}/data-discovery/assets/browse`,
+    RECOMMENDATIONS: `${API_BASE}/data-discovery/assets/recommendations`,
+    SIMILAR: `${API_BASE}/data-discovery/assets/similar`,
+    RELATED: `${API_BASE}/data-discovery/assets/related`,
+    TRENDING: `${API_BASE}/data-discovery/assets/trending`,
+    POPULAR: `${API_BASE}/data-discovery/assets/popular`,
+    RECENT: `${API_BASE}/data-discovery/assets/recent`,
+    BOOKMARKED: `${API_BASE}/data-discovery/assets/bookmarked`
+  },
+
+  // Discovery Workflows
+  WORKFLOWS: {
+    LIST: `${API_BASE}/data-discovery/workflows`,
+    CREATE: `${API_BASE}/data-discovery/workflows`,
+    GET: (id: string) => `${API_BASE}/data-discovery/workflows/${id}`,
+    UPDATE: (id: string) => `${API_BASE}/data-discovery/workflows/${id}`,
+    DELETE: (id: string) => `${API_BASE}/data-discovery/workflows/${id}`,
+    EXECUTE: (id: string) => `${API_BASE}/data-discovery/workflows/${id}/execute`,
+    SCHEDULE: (id: string) => `${API_BASE}/data-discovery/workflows/${id}/schedule`,
+    HISTORY: (id: string) => `${API_BASE}/data-discovery/workflows/${id}/history`
+  },
+
+  // Discovery Intelligence
+  INTELLIGENCE: {
+    INSIGHTS: `${API_BASE}/data-discovery/intelligence/insights`,
+    PATTERNS: `${API_BASE}/data-discovery/intelligence/patterns`,
+    ANOMALIES: `${API_BASE}/data-discovery/intelligence/anomalies`,
+    RELATIONSHIPS: `${API_BASE}/data-discovery/intelligence/relationships`,
+    CLUSTERING: `${API_BASE}/data-discovery/intelligence/clustering`,
+    CLASSIFICATION: `${API_BASE}/data-discovery/intelligence/classification`,
+    RECOMMENDATIONS: `${API_BASE}/data-discovery/intelligence/recommendations`,
+    AUTOMATION: `${API_BASE}/data-discovery/intelligence/automation`
+  }
+} as const;
+
+// ============================================================================
+// AI & ML ENDPOINTS (ai_routes.py, ml_routes.py)
+// ============================================================================
+
+export const AI_ENDPOINTS = {
+  // AI Services
+  AI: {
+    CHAT: `${API_BASE}/ai/chat`,
+    QUERY: `${API_BASE}/ai/query`,
+    ANALYZE: `${API_BASE}/ai/analyze`,
+    SUGGEST: `${API_BASE}/ai/suggest`,
+    CLASSIFY: `${API_BASE}/ai/classify`,
+    EXTRACT: `${API_BASE}/ai/extract`,
+    SUMMARIZE: `${API_BASE}/ai/summarize`,
+    TRANSLATE: `${API_BASE}/ai/translate`,
+    GENERATE: `${API_BASE}/ai/generate`,
+    EXPLAIN: `${API_BASE}/ai/explain`
+  },
+
+  // ML Services
+  ML: {
+    MODELS: `${API_BASE}/ml/models`,
+    TRAIN: `${API_BASE}/ml/train`,
+    PREDICT: `${API_BASE}/ml/predict`,
+    EVALUATE: `${API_BASE}/ml/evaluate`,
+    DEPLOY: `${API_BASE}/ml/deploy`,
+    MONITOR: `${API_BASE}/ml/monitor`,
+    FEATURES: `${API_BASE}/ml/features`,
+    PIPELINES: `${API_BASE}/ml/pipelines`,
+    EXPERIMENTS: `${API_BASE}/ml/experiments`,
+    REGISTRY: `${API_BASE}/ml/registry`
+  },
+
+  // Advanced AI
+  ADVANCED: {
+    NLP: `${API_BASE}/ai/advanced/nlp`,
+    COMPUTER_VISION: `${API_BASE}/ai/advanced/cv`,
+    DEEP_LEARNING: `${API_BASE}/ai/advanced/dl`,
+    REINFORCEMENT_LEARNING: `${API_BASE}/ai/advanced/rl`,
+    GENERATIVE_AI: `${API_BASE}/ai/advanced/gen`,
+    KNOWLEDGE_GRAPH: `${API_BASE}/ai/advanced/kg`,
+    REASONING: `${API_BASE}/ai/advanced/reasoning`,
+    PLANNING: `${API_BASE}/ai/advanced/planning`
+  }
+} as const;
+
+// ============================================================================
+// SHARED ENDPOINTS (Shared across multiple groups)
+// ============================================================================
+
+export const SHARED_ENDPOINTS = {
+  // Classification Services
+  CLASSIFICATION: {
+    CLASSIFY: `${API_BASE}/classification/classify`,
+    BATCH_CLASSIFY: `${API_BASE}/classification/batch`,
+    RULES: `${API_BASE}/classification/rules`,
+    MODELS: `${API_BASE}/classification/models`,
+    TRAIN: `${API_BASE}/classification/train`,
+    EVALUATE: `${API_BASE}/classification/evaluate`,
+    DEPLOY: `${API_BASE}/classification/deploy`,
+    PREDICT: `${API_BASE}/classification/predict`
+  },
+
+  // Enterprise Integration
+  INTEGRATION: {
+    CONNECTORS: `${API_BASE}/integration/connectors`,
+    APIS: `${API_BASE}/integration/apis`,
+    WEBHOOKS: `${API_BASE}/integration/webhooks`,
+    SYNC: `${API_BASE}/integration/sync`,
+    MAPPING: `${API_BASE}/integration/mapping`,
+    TRANSFORMATION: `${API_BASE}/integration/transformation`,
+    MONITORING: `${API_BASE}/integration/monitoring`,
+    HEALTH: `${API_BASE}/integration/health`
+  },
+
+  // Glossary Management
+  GLOSSARY: {
+    TERMS: `${API_BASE}/glossary/terms`,
+    CATEGORIES: `${API_BASE}/glossary/categories`,
+    RELATIONSHIPS: `${API_BASE}/glossary/relationships`,
+    ASSOCIATIONS: `${API_BASE}/glossary/associations`,
+    APPROVAL: `${API_BASE}/glossary/approval`,
+    WORKFLOW: `${API_BASE}/glossary/workflow`,
+    IMPORT: `${API_BASE}/glossary/import`,
+    EXPORT: `${API_BASE}/glossary/export`,
+    VALIDATE: `${API_BASE}/glossary/validate`,
+    SEARCH: `${API_BASE}/glossary/search`
+  }
+} as const;
+
+// ============================================================================
+// UTILITY FUNCTIONS
+// ============================================================================
+
+export const buildUrl = (endpoint: string, params?: Record<string, any>): string => {
+  if (!params) return endpoint;
+  
+  const url = new URL(endpoint);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.append(key, String(value));
+    }
+  });
+  
+  return url.toString();
+};
+
+export const buildPaginatedUrl = (
+  endpoint: string,
+  page: number = 1,
+  limit: number = 20,
+  params?: Record<string, any>
+): string => {
+  const paginationParams = { page, limit, ...params };
+  return buildUrl(endpoint, paginationParams);
+};
+
+export const isValidEndpoint = (endpoint: string): boolean => {
+  try {
+    new URL(endpoint);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Export all endpoint groups
+export const ALL_ENDPOINTS = {
+  ...ENTERPRISE_CATALOG_ENDPOINTS,
+  ...DISCOVERY_ENDPOINTS,
+  ...SEARCH_ENDPOINTS,
+  ...QUALITY_ENDPOINTS,
+  ...PROFILING_ENDPOINTS,
+  ...LINEAGE_ENDPOINTS,
+  ...ANALYTICS_ENDPOINTS,
+  ...ENTERPRISE_ANALYTICS_ENDPOINTS,
+  ...DATA_DISCOVERY_ENDPOINTS,
+  ...AI_ENDPOINTS,
+  ...SHARED_ENDPOINTS
+} as const;

--- a/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-schemas.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/constants/catalog-schemas.ts
@@ -1,0 +1,781 @@
+// ============================================================================
+// ADVANCED CATALOG SCHEMA CONSTANTS - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Schema definitions and validation rules for catalog assets
+// ============================================================================
+
+import { 
+  DataAssetType, 
+  SchemaFormat, 
+  DataType, 
+  SensitivityLevel 
+} from '../types';
+
+// ============================================================================
+// CORE ASSET SCHEMAS
+// ============================================================================
+
+export const ASSET_SCHEMAS = {
+  // Database Table Schema
+  TABLE: {
+    name: 'database_table',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255,
+        pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+      },
+      schema: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      database: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      columns: {
+        type: 'array',
+        required: true,
+        items: 'column_schema'
+      },
+      primaryKey: {
+        type: 'array',
+        items: 'string'
+      },
+      foreignKeys: {
+        type: 'array',
+        items: 'foreign_key_schema'
+      },
+      indexes: {
+        type: 'array',
+        items: 'index_schema'
+      },
+      partitioning: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['RANGE', 'HASH', 'LIST'] },
+          columns: { type: 'array', items: 'string' }
+        }
+      },
+      rowCount: {
+        type: 'number',
+        minimum: 0
+      },
+      sizeInBytes: {
+        type: 'number',
+        minimum: 0
+      }
+    }
+  },
+
+  // Database View Schema
+  VIEW: {
+    name: 'database_view',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255,
+        pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+      },
+      schema: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      database: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      definition: {
+        type: 'string',
+        required: true
+      },
+      columns: {
+        type: 'array',
+        required: true,
+        items: 'column_schema'
+      },
+      dependencies: {
+        type: 'array',
+        items: 'string'
+      },
+      materialized: {
+        type: 'boolean',
+        default: false
+      }
+    }
+  },
+
+  // File Asset Schema
+  FILE: {
+    name: 'file_asset',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      path: {
+        type: 'string',
+        required: true,
+        maxLength: 4096
+      },
+      format: {
+        type: 'string',
+        required: true,
+        enum: Object.values(SchemaFormat)
+      },
+      sizeInBytes: {
+        type: 'number',
+        required: true,
+        minimum: 0
+      },
+      lastModified: {
+        type: 'string',
+        format: 'date-time'
+      },
+      schema: {
+        type: 'object',
+        properties: {
+          columns: { type: 'array', items: 'column_schema' },
+          delimiter: { type: 'string' },
+          header: { type: 'boolean' },
+          encoding: { type: 'string', default: 'UTF-8' }
+        }
+      },
+      compression: {
+        type: 'string',
+        enum: ['NONE', 'GZIP', 'SNAPPY', 'LZO', 'BZIP2']
+      }
+    }
+  },
+
+  // API Endpoint Schema
+  API: {
+    name: 'api_endpoint',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      url: {
+        type: 'string',
+        required: true,
+        format: 'uri'
+      },
+      method: {
+        type: 'string',
+        required: true,
+        enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
+      },
+      parameters: {
+        type: 'array',
+        items: 'parameter_schema'
+      },
+      responseSchema: {
+        type: 'object',
+        properties: {
+          type: { type: 'string' },
+          properties: { type: 'object' }
+        }
+      },
+      authentication: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['NONE', 'BASIC', 'BEARER', 'API_KEY', 'OAUTH2'] },
+          required: { type: 'boolean' }
+        }
+      },
+      rateLimit: {
+        type: 'object',
+        properties: {
+          requests: { type: 'number' },
+          period: { type: 'string' }
+        }
+      }
+    }
+  },
+
+  // Dashboard Schema
+  DASHBOARD: {
+    name: 'dashboard',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      description: {
+        type: 'string',
+        maxLength: 2048
+      },
+      type: {
+        type: 'string',
+        enum: ['OPERATIONAL', 'ANALYTICAL', 'EXECUTIVE', 'REAL_TIME']
+      },
+      widgets: {
+        type: 'array',
+        items: 'widget_schema'
+      },
+      filters: {
+        type: 'array',
+        items: 'filter_schema'
+      },
+      refreshInterval: {
+        type: 'number',
+        minimum: 0
+      },
+      dataSources: {
+        type: 'array',
+        items: 'string'
+      }
+    }
+  }
+} as const;
+
+// ============================================================================
+// SUPPORTING SCHEMAS
+// ============================================================================
+
+export const SUPPORTING_SCHEMAS = {
+  // Column Schema
+  column_schema: {
+    name: 'column',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255,
+        pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+      },
+      dataType: {
+        type: 'string',
+        required: true,
+        enum: Object.values(DataType)
+      },
+      nullable: {
+        type: 'boolean',
+        default: true
+      },
+      defaultValue: {
+        type: 'any'
+      },
+      maxLength: {
+        type: 'number',
+        minimum: 0
+      },
+      precision: {
+        type: 'number',
+        minimum: 0
+      },
+      scale: {
+        type: 'number',
+        minimum: 0
+      },
+      description: {
+        type: 'string',
+        maxLength: 1024
+      },
+      tags: {
+        type: 'array',
+        items: 'string'
+      },
+      sensitivityLevel: {
+        type: 'string',
+        enum: Object.values(SensitivityLevel),
+        default: SensitivityLevel.INTERNAL
+      },
+      piiType: {
+        type: 'string',
+        enum: ['NAME', 'EMAIL', 'PHONE', 'SSN', 'CREDIT_CARD', 'ADDRESS', 'NONE'],
+        default: 'NONE'
+      }
+    }
+  },
+
+  // Foreign Key Schema
+  foreign_key_schema: {
+    name: 'foreign_key',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      columns: {
+        type: 'array',
+        required: true,
+        items: 'string'
+      },
+      referencedTable: {
+        type: 'string',
+        required: true
+      },
+      referencedColumns: {
+        type: 'array',
+        required: true,
+        items: 'string'
+      },
+      onDelete: {
+        type: 'string',
+        enum: ['CASCADE', 'SET_NULL', 'RESTRICT', 'NO_ACTION'],
+        default: 'NO_ACTION'
+      },
+      onUpdate: {
+        type: 'string',
+        enum: ['CASCADE', 'SET_NULL', 'RESTRICT', 'NO_ACTION'],
+        default: 'NO_ACTION'
+      }
+    }
+  },
+
+  // Index Schema
+  index_schema: {
+    name: 'index',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      type: {
+        type: 'string',
+        enum: ['BTREE', 'HASH', 'BITMAP', 'CLUSTERED', 'NON_CLUSTERED'],
+        default: 'BTREE'
+      },
+      columns: {
+        type: 'array',
+        required: true,
+        items: 'string'
+      },
+      unique: {
+        type: 'boolean',
+        default: false
+      },
+      partial: {
+        type: 'boolean',
+        default: false
+      },
+      condition: {
+        type: 'string'
+      }
+    }
+  },
+
+  // Parameter Schema (for APIs)
+  parameter_schema: {
+    name: 'parameter',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      type: {
+        type: 'string',
+        required: true,
+        enum: ['query', 'path', 'header', 'body']
+      },
+      dataType: {
+        type: 'string',
+        required: true,
+        enum: Object.values(DataType)
+      },
+      required: {
+        type: 'boolean',
+        default: false
+      },
+      description: {
+        type: 'string',
+        maxLength: 512
+      },
+      defaultValue: {
+        type: 'any'
+      },
+      enum: {
+        type: 'array',
+        items: 'any'
+      }
+    }
+  },
+
+  // Widget Schema (for Dashboards)
+  widget_schema: {
+    name: 'widget',
+    version: '1.0.0',
+    fields: {
+      id: {
+        type: 'string',
+        required: true
+      },
+      type: {
+        type: 'string',
+        required: true,
+        enum: ['CHART', 'TABLE', 'METRIC', 'TEXT', 'IMAGE']
+      },
+      title: {
+        type: 'string',
+        required: true,
+        maxLength: 255
+      },
+      position: {
+        type: 'object',
+        required: true,
+        properties: {
+          x: { type: 'number', minimum: 0 },
+          y: { type: 'number', minimum: 0 },
+          width: { type: 'number', minimum: 1 },
+          height: { type: 'number', minimum: 1 }
+        }
+      },
+      dataSource: {
+        type: 'string'
+      },
+      query: {
+        type: 'string'
+      },
+      configuration: {
+        type: 'object'
+      }
+    }
+  },
+
+  // Filter Schema
+  filter_schema: {
+    name: 'filter',
+    version: '1.0.0',
+    fields: {
+      name: {
+        type: 'string',
+        required: true,
+        maxLength: 128
+      },
+      field: {
+        type: 'string',
+        required: true
+      },
+      type: {
+        type: 'string',
+        required: true,
+        enum: ['TEXT', 'NUMBER', 'DATE', 'SELECT', 'MULTI_SELECT', 'BOOLEAN']
+      },
+      defaultValue: {
+        type: 'any'
+      },
+      options: {
+        type: 'array',
+        items: 'object'
+      },
+      required: {
+        type: 'boolean',
+        default: false
+      }
+    }
+  }
+} as const;
+
+// ============================================================================
+// VALIDATION RULES
+// ============================================================================
+
+export const VALIDATION_RULES = {
+  // Asset Name Validation
+  ASSET_NAME: {
+    pattern: /^[a-zA-Z][a-zA-Z0-9_-]*$/,
+    minLength: 1,
+    maxLength: 255,
+    description: 'Asset name must start with a letter and contain only letters, numbers, underscores, and hyphens'
+  },
+
+  // Column Name Validation
+  COLUMN_NAME: {
+    pattern: /^[a-zA-Z][a-zA-Z0-9_]*$/,
+    minLength: 1,
+    maxLength: 255,
+    description: 'Column name must start with a letter and contain only letters, numbers, and underscores'
+  },
+
+  // Schema Name Validation
+  SCHEMA_NAME: {
+    pattern: /^[a-zA-Z][a-zA-Z0-9_]*$/,
+    minLength: 1,
+    maxLength: 128,
+    description: 'Schema name must start with a letter and contain only letters, numbers, and underscores'
+  },
+
+  // Database Name Validation
+  DATABASE_NAME: {
+    pattern: /^[a-zA-Z][a-zA-Z0-9_]*$/,
+    minLength: 1,
+    maxLength: 128,
+    description: 'Database name must start with a letter and contain only letters, numbers, and underscores'
+  },
+
+  // File Path Validation
+  FILE_PATH: {
+    pattern: /^[a-zA-Z0-9_\-/.]+$/,
+    minLength: 1,
+    maxLength: 4096,
+    description: 'File path must contain only valid path characters'
+  },
+
+  // URL Validation
+  URL: {
+    pattern: /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/,
+    description: 'Must be a valid HTTP or HTTPS URL'
+  },
+
+  // Tag Validation
+  TAG: {
+    pattern: /^[a-zA-Z0-9_-]+$/,
+    minLength: 1,
+    maxLength: 64,
+    description: 'Tag must contain only letters, numbers, underscores, and hyphens'
+  },
+
+  // Description Validation
+  DESCRIPTION: {
+    minLength: 0,
+    maxLength: 2048,
+    description: 'Description must be less than 2048 characters'
+  }
+} as const;
+
+// ============================================================================
+// SCHEMA TEMPLATES
+// ============================================================================
+
+export const SCHEMA_TEMPLATES = {
+  // Standard Data Warehouse Table Template
+  DATA_WAREHOUSE_TABLE: {
+    name: 'Standard Data Warehouse Table',
+    description: 'Template for standard data warehouse dimension and fact tables',
+    schema: {
+      ...ASSET_SCHEMAS.TABLE,
+      defaultFields: {
+        created_date: {
+          dataType: DataType.DATETIME,
+          nullable: false,
+          description: 'Record creation timestamp'
+        },
+        updated_date: {
+          dataType: DataType.DATETIME,
+          nullable: false,
+          description: 'Record last update timestamp'
+        },
+        is_active: {
+          dataType: DataType.BOOLEAN,
+          nullable: false,
+          defaultValue: true,
+          description: 'Record active status'
+        },
+        data_source: {
+          dataType: DataType.STRING,
+          nullable: false,
+          maxLength: 128,
+          description: 'Source system identifier'
+        }
+      }
+    }
+  },
+
+  // Customer Data Template
+  CUSTOMER_DATA: {
+    name: 'Customer Data Table',
+    description: 'Template for customer-related data with PII considerations',
+    schema: {
+      ...ASSET_SCHEMAS.TABLE,
+      defaultFields: {
+        customer_id: {
+          dataType: DataType.STRING,
+          nullable: false,
+          description: 'Unique customer identifier',
+          sensitivityLevel: SensitivityLevel.INTERNAL
+        },
+        email: {
+          dataType: DataType.STRING,
+          nullable: true,
+          maxLength: 255,
+          description: 'Customer email address',
+          sensitivityLevel: SensitivityLevel.CONFIDENTIAL,
+          piiType: 'EMAIL'
+        },
+        phone: {
+          dataType: DataType.STRING,
+          nullable: true,
+          maxLength: 20,
+          description: 'Customer phone number',
+          sensitivityLevel: SensitivityLevel.CONFIDENTIAL,
+          piiType: 'PHONE'
+        },
+        created_date: {
+          dataType: DataType.DATETIME,
+          nullable: false,
+          description: 'Customer record creation date'
+        }
+      }
+    }
+  },
+
+  // Financial Data Template
+  FINANCIAL_DATA: {
+    name: 'Financial Data Table',
+    description: 'Template for financial data with high security requirements',
+    schema: {
+      ...ASSET_SCHEMAS.TABLE,
+      defaultFields: {
+        transaction_id: {
+          dataType: DataType.STRING,
+          nullable: false,
+          description: 'Unique transaction identifier',
+          sensitivityLevel: SensitivityLevel.CONFIDENTIAL
+        },
+        amount: {
+          dataType: DataType.DECIMAL,
+          nullable: false,
+          precision: 15,
+          scale: 2,
+          description: 'Transaction amount',
+          sensitivityLevel: SensitivityLevel.RESTRICTED
+        },
+        currency: {
+          dataType: DataType.STRING,
+          nullable: false,
+          maxLength: 3,
+          description: 'Currency code (ISO 4217)'
+        },
+        transaction_date: {
+          dataType: DataType.DATETIME,
+          nullable: false,
+          description: 'Transaction timestamp'
+        }
+      }
+    }
+  },
+
+  // Log Data Template
+  LOG_DATA: {
+    name: 'Log Data File',
+    description: 'Template for log file data',
+    schema: {
+      ...ASSET_SCHEMAS.FILE,
+      defaultFields: {
+        timestamp: {
+          dataType: DataType.DATETIME,
+          nullable: false,
+          description: 'Log entry timestamp'
+        },
+        level: {
+          dataType: DataType.STRING,
+          nullable: false,
+          maxLength: 10,
+          description: 'Log level (ERROR, WARN, INFO, DEBUG)'
+        },
+        message: {
+          dataType: DataType.STRING,
+          nullable: false,
+          maxLength: 4096,
+          description: 'Log message content'
+        },
+        source: {
+          dataType: DataType.STRING,
+          nullable: false,
+          maxLength: 128,
+          description: 'Log source identifier'
+        }
+      }
+    }
+  }
+} as const;
+
+// ============================================================================
+// SCHEMA CATEGORIES
+// ============================================================================
+
+export const SCHEMA_CATEGORIES = {
+  STRUCTURED_DATA: {
+    name: 'Structured Data',
+    description: 'Well-defined schema with fixed columns and data types',
+    assetTypes: [DataAssetType.TABLE, DataAssetType.VIEW],
+    characteristics: ['Fixed schema', 'Relational', 'ACID compliant']
+  },
+
+  SEMI_STRUCTURED_DATA: {
+    name: 'Semi-Structured Data',
+    description: 'Flexible schema with some organizational structure',
+    assetTypes: [DataAssetType.FILE],
+    formats: [SchemaFormat.JSON, SchemaFormat.AVRO, SchemaFormat.PARQUET],
+    characteristics: ['Flexible schema', 'Self-describing', 'Hierarchical']
+  },
+
+  UNSTRUCTURED_DATA: {
+    name: 'Unstructured Data',
+    description: 'No predefined schema or structure',
+    assetTypes: [DataAssetType.FILE],
+    formats: ['TEXT', 'BINARY', 'IMAGE', 'VIDEO', 'AUDIO'],
+    characteristics: ['No schema', 'Free-form', 'Content-based']
+  },
+
+  STREAMING_DATA: {
+    name: 'Streaming Data',
+    description: 'Continuous data streams with time-series characteristics',
+    assetTypes: [DataAssetType.STREAM],
+    characteristics: ['Time-series', 'Continuous', 'Real-time', 'Event-driven']
+  },
+
+  API_DATA: {
+    name: 'API Data',
+    description: 'Data accessed through API endpoints',
+    assetTypes: [DataAssetType.API],
+    characteristics: ['REST/GraphQL', 'Request-response', 'Rate-limited', 'Authenticated']
+  }
+} as const;
+
+// ============================================================================
+// DEFAULT CONFIGURATIONS
+// ============================================================================
+
+export const DEFAULT_CONFIGS = {
+  // Default asset configuration
+  ASSET: {
+    sensitivityLevel: SensitivityLevel.INTERNAL,
+    status: 'ACTIVE',
+    qualityThreshold: 0.8,
+    enableLineageTracking: true,
+    enableQualityMonitoring: true,
+    enableUsageTracking: true
+  },
+
+  // Default column configuration
+  COLUMN: {
+    nullable: true,
+    sensitivityLevel: SensitivityLevel.INTERNAL,
+    piiType: 'NONE',
+    enableProfiling: true,
+    enableQualityRules: true
+  },
+
+  // Default schema configuration
+  SCHEMA: {
+    version: '1.0.0',
+    enableValidation: true,
+    strictMode: false,
+    allowAdditionalFields: true,
+    enableEvolution: true
+  }
+} as const;

--- a/v15_enhanced_1/components/Advanced-Catalog/constants/index.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/constants/index.ts
@@ -1,0 +1,68 @@
+// ============================================================================
+// ADVANCED CATALOG CONSTANTS INDEX - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Centralized export point for all catalog constants
+// ============================================================================
+
+// Export all constants from individual files
+export * from './catalog-constants';
+export * from './catalog-endpoints';
+export * from './catalog-schemas';
+
+// Re-export specific constant groups for convenience
+export {
+  CATALOG_CONFIG,
+  ASSET_CONSTANTS,
+  QUALITY_CONSTANTS,
+  LINEAGE_CONSTANTS,
+  SEARCH_CONSTANTS,
+  ANALYTICS_CONSTANTS,
+  DISCOVERY_CONSTANTS,
+  UI_CONSTANTS,
+  NOTIFICATION_CONSTANTS,
+  ERROR_CONSTANTS,
+  ALL_CONSTANTS
+} from './catalog-constants';
+
+export {
+  API_CONFIG,
+  API_BASE,
+  ENTERPRISE_CATALOG_ENDPOINTS,
+  DISCOVERY_ENDPOINTS,
+  SEARCH_ENDPOINTS,
+  QUALITY_ENDPOINTS,
+  PROFILING_ENDPOINTS,
+  LINEAGE_ENDPOINTS,
+  ANALYTICS_ENDPOINTS,
+  ENTERPRISE_ANALYTICS_ENDPOINTS,
+  DATA_DISCOVERY_ENDPOINTS,
+  AI_ENDPOINTS,
+  SHARED_ENDPOINTS,
+  ALL_ENDPOINTS,
+  buildUrl,
+  buildPaginatedUrl,
+  isValidEndpoint
+} from './catalog-endpoints';
+
+export {
+  ASSET_SCHEMAS,
+  SUPPORTING_SCHEMAS,
+  VALIDATION_RULES,
+  SCHEMA_TEMPLATES,
+  SCHEMA_CATEGORIES,
+  DEFAULT_CONFIGS
+} from './catalog-schemas';
+
+// Default export for convenience
+import ALL_CONSTANTS from './catalog-constants';
+import { ALL_ENDPOINTS } from './catalog-endpoints';
+import { ASSET_SCHEMAS, SUPPORTING_SCHEMAS } from './catalog-schemas';
+
+export default {
+  ...ALL_CONSTANTS,
+  ENDPOINTS: ALL_ENDPOINTS,
+  SCHEMAS: {
+    ...ASSET_SCHEMAS,
+    ...SUPPORTING_SCHEMAS
+  }
+};

--- a/v15_enhanced_1/components/Advanced-Catalog/services/catalog-quality.service.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/services/catalog-quality.service.ts
@@ -1,0 +1,1396 @@
+// ============================================================================
+// CATALOG QUALITY SERVICE - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: catalog_quality_service.py
+// Data quality management, assessment, monitoring, and reporting
+// ============================================================================
+
+import axios from 'axios';
+import { 
+  QualityDashboard,
+  QualityAssessmentJob,
+  QualityAssessmentResult,
+  DataQualityRule,
+  QualityIssue,
+  QualityTrend,
+  QualityRecommendation,
+  QualityMonitoring,
+  QualityReport,
+  QualityProfile,
+  QualityBaseline,
+  CatalogApiResponse
+} from '../types';
+import { 
+  QUALITY_ENDPOINTS, 
+  buildUrl,
+  buildPaginatedUrl 
+} from '../constants';
+
+// ============================================================================
+// QUALITY SERVICE INTERFACES
+// ============================================================================
+
+export interface CreateQualityAssessmentRequest {
+  name: string;
+  description?: string;
+  assetIds: string[];
+  ruleIds: string[];
+  schedule?: QualityScheduleConfig;
+  notifications?: QualityNotificationConfig[];
+  configuration?: QualityAssessmentConfig;
+  metadata?: Record<string, any>;
+}
+
+export interface QualityScheduleConfig {
+  type: 'ONCE' | 'RECURRING';
+  cronExpression?: string;
+  startTime?: Date;
+  enabled?: boolean;
+  timezone?: string;
+}
+
+export interface QualityNotificationConfig {
+  type: 'EMAIL' | 'WEBHOOK' | 'SLACK';
+  recipients: string[];
+  events: string[];
+  threshold?: number;
+  template?: string;
+}
+
+export interface QualityAssessmentConfig {
+  enableTrends: boolean;
+  enableRecommendations: boolean;
+  scoreThreshold: number;
+  failureThreshold: number;
+  samplingRate?: number;
+  timeoutMinutes?: number;
+  parallelExecution?: boolean;
+}
+
+export interface CreateQualityRuleRequest {
+  name: string;
+  description: string;
+  ruleType: 'COMPLETENESS' | 'ACCURACY' | 'CONSISTENCY' | 'VALIDITY' | 'UNIQUENESS' | 'TIMELINESS' | 'CUSTOM';
+  dimension: string;
+  expression: string;
+  threshold: QualityThresholdConfig;
+  severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL' | 'BLOCKING';
+  scope: QualityRuleScopeConfig;
+  schedule?: QualityScheduleConfig;
+  enabled?: boolean;
+  metadata?: Record<string, any>;
+}
+
+export interface QualityThresholdConfig {
+  value: number;
+  operator: 'GREATER_THAN' | 'LESS_THAN' | 'EQUALS' | 'BETWEEN' | 'NOT_EQUALS';
+  upperBound?: number;
+  unit?: string;
+}
+
+export interface QualityRuleScopeConfig {
+  assetTypes: string[];
+  assetIds?: string[];
+  columns?: string[];
+  conditions?: string[];
+}
+
+export interface CreateQualityDashboardRequest {
+  name: string;
+  description?: string;
+  widgets: QualityWidgetConfig[];
+  filters?: QualityFilterConfig[];
+  timeRange?: QualityTimeRangeConfig;
+  refreshInterval?: number;
+  layout?: QualityDashboardLayoutConfig;
+  permissions?: QualityPermissionConfig;
+}
+
+export interface QualityWidgetConfig {
+  id: string;
+  type: 'SCORE_CARD' | 'TREND_CHART' | 'ISSUE_SUMMARY' | 'RULE_STATUS' | 'HEAT_MAP' | 'DISTRIBUTION_CHART';
+  title: string;
+  position: { x: number; y: number; width: number; height: number };
+  dataSource: string;
+  configuration: any;
+  refreshInterval?: number;
+}
+
+export interface QualityFilterConfig {
+  field: string;
+  operator: string;
+  value: any;
+  enabled: boolean;
+}
+
+export interface QualityTimeRangeConfig {
+  type: 'RELATIVE' | 'ABSOLUTE';
+  value?: string;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface QualityDashboardLayoutConfig {
+  columns: number;
+  spacing: number;
+  responsive: boolean;
+}
+
+export interface QualityPermissionConfig {
+  public: boolean;
+  users: string[];
+  groups: string[];
+  roles: string[];
+}
+
+export interface CreateQualityMonitoringRequest {
+  name: string;
+  description?: string;
+  scope: QualityMonitoringScopeConfig;
+  rules: string[];
+  thresholds: QualityThresholdConfig[];
+  alerting: QualityAlertingConfig;
+  schedule: QualityScheduleConfig;
+}
+
+export interface QualityMonitoringScopeConfig {
+  assetIds: string[];
+  includeChildAssets: boolean;
+  filters?: QualityFilterConfig[];
+}
+
+export interface QualityAlertingConfig {
+  enabled: boolean;
+  channels: QualityNotificationConfig[];
+  escalation?: QualityEscalationConfig;
+  suppressDuplicates?: boolean;
+  suppressionWindow?: number;
+}
+
+export interface QualityEscalationConfig {
+  levels: Array<{
+    threshold: number;
+    delay: number;
+    recipients: string[];
+  }>;
+}
+
+export interface CreateQualityReportRequest {
+  name: string;
+  description?: string;
+  type: 'EXECUTIVE_SUMMARY' | 'DETAILED_ANALYSIS' | 'TREND_REPORT' | 'COMPLIANCE_REPORT' | 'ISSUE_REPORT';
+  scope: QualityReportScopeConfig;
+  template?: string;
+  schedule?: QualityScheduleConfig;
+  distribution?: QualityDistributionConfig;
+  format?: string[];
+}
+
+export interface QualityReportScopeConfig {
+  assetIds?: string[];
+  ruleIds?: string[];
+  timeRange: QualityTimeRangeConfig;
+  includeHistory: boolean;
+  includeTrends: boolean;
+  includeRecommendations: boolean;
+}
+
+export interface QualityDistributionConfig {
+  recipients: string[];
+  channels: string[];
+  schedule: QualityScheduleConfig;
+}
+
+export interface QualityAnalyticsRequest {
+  startDate: Date;
+  endDate: Date;
+  assetIds?: string[];
+  ruleIds?: string[];
+  granularity?: 'HOUR' | 'DAY' | 'WEEK' | 'MONTH';
+  metrics: string[];
+  groupBy?: string[];
+}
+
+export interface QualityIssueUpdateRequest {
+  status?: 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED' | 'REOPENED' | 'DEFERRED';
+  assignedTo?: string;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT' | 'CRITICAL';
+  dueDate?: Date;
+  comments?: string;
+  resolution?: QualityIssueResolutionRequest;
+}
+
+export interface QualityIssueResolutionRequest {
+  type: 'FIXED' | 'ACKNOWLEDGED' | 'FALSE_POSITIVE' | 'WONT_FIX' | 'DUPLICATE';
+  description: string;
+  actions: string[];
+  preventionMeasures?: string[];
+}
+
+// ============================================================================
+// CATALOG QUALITY SERVICE CLASS
+// ============================================================================
+
+export class CatalogQualityService {
+
+  // ============================================================================
+  // QUALITY ASSESSMENT OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get list of quality assessments
+   */
+  async getQualityAssessments(
+    page: number = 1,
+    limit: number = 20,
+    status?: string,
+    assetId?: string,
+    sortBy?: string,
+    sortOrder?: 'ASC' | 'DESC'
+  ): Promise<CatalogApiResponse<{
+    assessments: QualityAssessmentJob[];
+    totalCount: number;
+  }>> {
+    const params = {
+      page,
+      limit,
+      status,
+      assetId,
+      sortBy,
+      sortOrder
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      assessments: QualityAssessmentJob[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(QUALITY_ENDPOINTS.ASSESSMENTS.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create new quality assessment
+   */
+  async createQualityAssessment(
+    request: CreateQualityAssessmentRequest
+  ): Promise<CatalogApiResponse<QualityAssessmentJob>> {
+    const response = await axios.post<CatalogApiResponse<QualityAssessmentJob>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality assessment by ID
+   */
+  async getQualityAssessment(
+    id: string,
+    includeResults: boolean = false
+  ): Promise<CatalogApiResponse<QualityAssessmentJob>> {
+    const params = { includeResults };
+
+    const response = await axios.get<CatalogApiResponse<QualityAssessmentJob>>(
+      buildUrl(QUALITY_ENDPOINTS.ASSESSMENTS.GET(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update quality assessment
+   */
+  async updateQualityAssessment(
+    id: string,
+    updates: Partial<CreateQualityAssessmentRequest>
+  ): Promise<CatalogApiResponse<QualityAssessmentJob>> {
+    const response = await axios.put<CatalogApiResponse<QualityAssessmentJob>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete quality assessment
+   */
+  async deleteQualityAssessment(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.DELETE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Run quality assessment
+   */
+  async runQualityAssessment(
+    id: string,
+    overrideConfiguration?: Partial<QualityAssessmentConfig>
+  ): Promise<CatalogApiResponse<{ executionId: string; estimatedDuration: number }>> {
+    const request = { overrideConfiguration };
+
+    const response = await axios.post<CatalogApiResponse<{ executionId: string; estimatedDuration: number }>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.RUN(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Schedule quality assessment
+   */
+  async scheduleQualityAssessment(
+    id: string,
+    schedule: QualityScheduleConfig
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.SCHEDULE(id),
+      schedule
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality assessment results
+   */
+  async getQualityAssessmentResults(
+    id: string,
+    includeDetails: boolean = true,
+    includeIssues: boolean = true
+  ): Promise<CatalogApiResponse<QualityAssessmentResult[]>> {
+    const params = { includeDetails, includeIssues };
+
+    const response = await axios.get<CatalogApiResponse<QualityAssessmentResult[]>>(
+      buildUrl(QUALITY_ENDPOINTS.ASSESSMENTS.RESULTS(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality assessment history
+   */
+  async getQualityAssessmentHistory(
+    id: string,
+    limit: number = 50
+  ): Promise<CatalogApiResponse<Array<{
+    executionId: string;
+    startTime: Date;
+    endTime: Date;
+    status: string;
+    summary: any;
+  }>>> {
+    const params = { limit };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      executionId: string;
+      startTime: Date;
+      endTime: Date;
+      status: string;
+      summary: any;
+    }>>>(
+      buildUrl(QUALITY_ENDPOINTS.ASSESSMENTS.HISTORY(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality assessment trends
+   */
+  async getQualityAssessmentTrends(
+    id: string,
+    period: string = '30d',
+    granularity: 'HOUR' | 'DAY' | 'WEEK' = 'DAY'
+  ): Promise<CatalogApiResponse<QualityTrend[]>> {
+    const params = { period, granularity };
+
+    const response = await axios.get<CatalogApiResponse<QualityTrend[]>>(
+      buildUrl(QUALITY_ENDPOINTS.ASSESSMENTS.TRENDS(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Export quality assessment results
+   */
+  async exportQualityAssessmentResults(
+    id: string,
+    format: 'CSV' | 'EXCEL' | 'PDF' | 'JSON',
+    includeDetails: boolean = true
+  ): Promise<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>> {
+    const request = { format, includeDetails };
+
+    const response = await axios.post<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>>(
+      QUALITY_ENDPOINTS.ASSESSMENTS.EXPORT(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // QUALITY RULES MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get list of quality rules
+   */
+  async getQualityRules(
+    page: number = 1,
+    limit: number = 20,
+    ruleType?: string,
+    enabled?: boolean,
+    category?: string
+  ): Promise<CatalogApiResponse<{
+    rules: DataQualityRule[];
+    totalCount: number;
+  }>> {
+    const params = {
+      page,
+      limit,
+      ruleType,
+      enabled,
+      category
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      rules: DataQualityRule[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(QUALITY_ENDPOINTS.RULES.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create new quality rule
+   */
+  async createQualityRule(
+    request: CreateQualityRuleRequest
+  ): Promise<CatalogApiResponse<DataQualityRule>> {
+    const response = await axios.post<CatalogApiResponse<DataQualityRule>>(
+      QUALITY_ENDPOINTS.RULES.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality rule by ID
+   */
+  async getQualityRule(id: string): Promise<CatalogApiResponse<DataQualityRule>> {
+    const response = await axios.get<CatalogApiResponse<DataQualityRule>>(
+      QUALITY_ENDPOINTS.RULES.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update quality rule
+   */
+  async updateQualityRule(
+    id: string,
+    updates: Partial<CreateQualityRuleRequest>
+  ): Promise<CatalogApiResponse<DataQualityRule>> {
+    const response = await axios.put<CatalogApiResponse<DataQualityRule>>(
+      QUALITY_ENDPOINTS.RULES.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete quality rule
+   */
+  async deleteQualityRule(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.RULES.DELETE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Validate quality rule
+   */
+  async validateQualityRule(
+    rule: CreateQualityRuleRequest
+  ): Promise<CatalogApiResponse<{
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+    suggestions: string[];
+  }>> {
+    const response = await axios.post<CatalogApiResponse<{
+      valid: boolean;
+      errors: string[];
+      warnings: string[];
+      suggestions: string[];
+    }>>(
+      QUALITY_ENDPOINTS.RULES.VALIDATE,
+      rule
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality rule templates
+   */
+  async getQualityRuleTemplates(
+    category?: string
+  ): Promise<CatalogApiResponse<Array<{
+    id: string;
+    name: string;
+    description: string;
+    category: string;
+    template: Partial<CreateQualityRuleRequest>;
+  }>>> {
+    const params = category ? { category } : {};
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      id: string;
+      name: string;
+      description: string;
+      category: string;
+      template: Partial<CreateQualityRuleRequest>;
+    }>>>(
+      buildUrl(QUALITY_ENDPOINTS.RULES.TEMPLATES, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Execute quality rule
+   */
+  async executeQualityRule(
+    id: string,
+    assetIds: string[],
+    dryRun: boolean = false
+  ): Promise<CatalogApiResponse<{
+    executionId: string;
+    results: any[];
+    summary: any;
+  }>> {
+    const request = { assetIds, dryRun };
+
+    const response = await axios.post<CatalogApiResponse<{
+      executionId: string;
+      results: any[];
+      summary: any;
+    }>>(
+      QUALITY_ENDPOINTS.RULES.EXECUTE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Test quality rule
+   */
+  async testQualityRule(
+    id: string,
+    testData: any,
+    sampleSize: number = 100
+  ): Promise<CatalogApiResponse<{
+    passed: boolean;
+    score: number;
+    details: any;
+    sampleResults: any[];
+  }>> {
+    const request = { testData, sampleSize };
+
+    const response = await axios.post<CatalogApiResponse<{
+      passed: boolean;
+      score: number;
+      details: any;
+      sampleResults: any[];
+    }>>(
+      QUALITY_ENDPOINTS.RULES.TEST(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Duplicate quality rule
+   */
+  async duplicateQualityRule(
+    id: string,
+    newName: string,
+    modifications?: Partial<CreateQualityRuleRequest>
+  ): Promise<CatalogApiResponse<DataQualityRule>> {
+    const request = { newName, modifications };
+
+    const response = await axios.post<CatalogApiResponse<DataQualityRule>>(
+      QUALITY_ENDPOINTS.RULES.DUPLICATE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality rule library
+   */
+  async getQualityRuleLibrary(): Promise<CatalogApiResponse<{
+    categories: string[];
+    rules: any[];
+    templates: any[];
+    customRules: any[];
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      categories: string[];
+      rules: any[];
+      templates: any[];
+      customRules: any[];
+    }>>(
+      QUALITY_ENDPOINTS.RULES.LIBRARY
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality rule categories
+   */
+  async getQualityRuleCategories(): Promise<CatalogApiResponse<Array<{
+    name: string;
+    description: string;
+    ruleCount: number;
+  }>>> {
+    const response = await axios.get<CatalogApiResponse<Array<{
+      name: string;
+      description: string;
+      ruleCount: number;
+    }>>>(
+      QUALITY_ENDPOINTS.RULES.CATEGORIES
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // QUALITY DASHBOARD OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get quality dashboard overview
+   */
+  async getQualityDashboardOverview(): Promise<CatalogApiResponse<QualityDashboard>> {
+    const response = await axios.get<CatalogApiResponse<QualityDashboard>>(
+      QUALITY_ENDPOINTS.DASHBOARD.OVERVIEW
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality scorecard
+   */
+  async getQualityScorecard(
+    assetIds?: string[],
+    period?: string
+  ): Promise<CatalogApiResponse<{
+    overallScore: number;
+    assetScores: any[];
+    dimensionScores: any[];
+    trends: any[];
+    insights: any[];
+  }>> {
+    const params = {
+      assetIds: assetIds ? assetIds.join(',') : undefined,
+      period
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      overallScore: number;
+      assetScores: any[];
+      dimensionScores: any[];
+      trends: any[];
+      insights: any[];
+    }>>(
+      buildUrl(QUALITY_ENDPOINTS.DASHBOARD.SCORECARD, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality trends
+   */
+  async getQualityTrends(
+    period: string = '30d',
+    granularity: 'HOUR' | 'DAY' | 'WEEK' = 'DAY',
+    assetIds?: string[]
+  ): Promise<CatalogApiResponse<QualityTrend[]>> {
+    const params = {
+      period,
+      granularity,
+      assetIds: assetIds ? assetIds.join(',') : undefined
+    };
+
+    const response = await axios.get<CatalogApiResponse<QualityTrend[]>>(
+      buildUrl(QUALITY_ENDPOINTS.DASHBOARD.TRENDS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality issues summary
+   */
+  async getQualityIssuesSummary(
+    severity?: string,
+    status?: string,
+    assetIds?: string[]
+  ): Promise<CatalogApiResponse<{
+    totalIssues: number;
+    openIssues: number;
+    criticalIssues: number;
+    issuesBySeverity: any[];
+    issuesByType: any[];
+    recentIssues: QualityIssue[];
+  }>> {
+    const params = {
+      severity,
+      status,
+      assetIds: assetIds ? assetIds.join(',') : undefined
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      totalIssues: number;
+      openIssues: number;
+      criticalIssues: number;
+      issuesBySeverity: any[];
+      issuesByType: any[];
+      recentIssues: QualityIssue[];
+    }>>(
+      buildUrl(QUALITY_ENDPOINTS.DASHBOARD.ISSUES, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality alerts
+   */
+  async getQualityAlerts(
+    active: boolean = true,
+    limit: number = 20
+  ): Promise<CatalogApiResponse<Array<{
+    id: string;
+    type: string;
+    severity: string;
+    message: string;
+    assetId: string;
+    ruleId: string;
+    triggeredAt: Date;
+    acknowledged: boolean;
+  }>>> {
+    const params = { active, limit };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      id: string;
+      type: string;
+      severity: string;
+      message: string;
+      assetId: string;
+      ruleId: string;
+      triggeredAt: Date;
+      acknowledged: boolean;
+    }>>>(
+      buildUrl(QUALITY_ENDPOINTS.DASHBOARD.ALERTS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality reports
+   */
+  async getQualityReports(
+    type?: string,
+    status?: string
+  ): Promise<CatalogApiResponse<QualityReport[]>> {
+    const params = { type, status };
+
+    const response = await axios.get<CatalogApiResponse<QualityReport[]>>(
+      buildUrl(QUALITY_ENDPOINTS.DASHBOARD.REPORTS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get dashboard widgets configuration
+   */
+  async getDashboardWidgets(): Promise<CatalogApiResponse<QualityWidgetConfig[]>> {
+    const response = await axios.get<CatalogApiResponse<QualityWidgetConfig[]>>(
+      QUALITY_ENDPOINTS.DASHBOARD.WIDGETS
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Personalize quality dashboard
+   */
+  async personalizeQualityDashboard(
+    userId: string,
+    configuration: CreateQualityDashboardRequest
+  ): Promise<CatalogApiResponse<void>> {
+    const request = { userId, configuration };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.DASHBOARD.PERSONALIZE,
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // QUALITY ISSUES MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get list of quality issues
+   */
+  async getQualityIssues(
+    page: number = 1,
+    limit: number = 20,
+    severity?: string,
+    status?: string,
+    assetId?: string,
+    ruleId?: string,
+    assignedTo?: string
+  ): Promise<CatalogApiResponse<{
+    issues: QualityIssue[];
+    totalCount: number;
+  }>> {
+    const params = {
+      page,
+      limit,
+      severity,
+      status,
+      assetId,
+      ruleId,
+      assignedTo
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      issues: QualityIssue[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(QUALITY_ENDPOINTS.ISSUES.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality issue by ID
+   */
+  async getQualityIssue(id: string): Promise<CatalogApiResponse<QualityIssue>> {
+    const response = await axios.get<CatalogApiResponse<QualityIssue>>(
+      QUALITY_ENDPOINTS.ISSUES.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update quality issue
+   */
+  async updateQualityIssue(
+    id: string,
+    updates: QualityIssueUpdateRequest
+  ): Promise<CatalogApiResponse<QualityIssue>> {
+    const response = await axios.put<CatalogApiResponse<QualityIssue>>(
+      QUALITY_ENDPOINTS.ISSUES.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Resolve quality issue
+   */
+  async resolveQualityIssue(
+    id: string,
+    resolution: QualityIssueResolutionRequest
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ISSUES.RESOLVE(id),
+      resolution
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Assign quality issue
+   */
+  async assignQualityIssue(
+    id: string,
+    assignedTo: string,
+    dueDate?: Date,
+    comments?: string
+  ): Promise<CatalogApiResponse<void>> {
+    const request = { assignedTo, dueDate, comments };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ISSUES.ASSIGN(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Add comment to quality issue
+   */
+  async addQualityIssueComment(
+    id: string,
+    comment: string,
+    userId: string
+  ): Promise<CatalogApiResponse<void>> {
+    const request = { comment, userId };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ISSUES.COMMENT(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Track quality issue
+   */
+  async trackQualityIssue(
+    id: string,
+    action: string,
+    details?: any
+  ): Promise<CatalogApiResponse<void>> {
+    const request = { action, details };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.ISSUES.TRACK(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Bulk update quality issues
+   */
+  async bulkUpdateQualityIssues(
+    issueIds: string[],
+    updates: QualityIssueUpdateRequest
+  ): Promise<CatalogApiResponse<{
+    updated: number;
+    failed: number;
+    errors: any[];
+  }>> {
+    const request = { issueIds, updates };
+
+    const response = await axios.post<CatalogApiResponse<{
+      updated: number;
+      failed: number;
+      errors: any[];
+    }>>(
+      QUALITY_ENDPOINTS.ISSUES.BULK_UPDATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality issues statistics
+   */
+  async getQualityIssuesStatistics(
+    period: string = '30d'
+  ): Promise<CatalogApiResponse<{
+    totalIssues: number;
+    openIssues: number;
+    resolvedIssues: number;
+    averageResolutionTime: number;
+    issuesByType: any[];
+    issuesBySeverity: any[];
+    issuesByAsset: any[];
+    resolutionTrends: any[];
+  }>> {
+    const params = { period };
+
+    const response = await axios.get<CatalogApiResponse<{
+      totalIssues: number;
+      openIssues: number;
+      resolvedIssues: number;
+      averageResolutionTime: number;
+      issuesByType: any[];
+      issuesBySeverity: any[];
+      issuesByAsset: any[];
+      resolutionTrends: any[];
+    }>>(
+      buildUrl(QUALITY_ENDPOINTS.ISSUES.STATISTICS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality issues trends
+   */
+  async getQualityIssuesTrends(
+    period: string = '30d',
+    granularity: 'HOUR' | 'DAY' | 'WEEK' = 'DAY'
+  ): Promise<CatalogApiResponse<Array<{
+    date: Date;
+    openIssues: number;
+    newIssues: number;
+    resolvedIssues: number;
+    criticalIssues: number;
+  }>>> {
+    const params = { period, granularity };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      date: Date;
+      openIssues: number;
+      newIssues: number;
+      resolvedIssues: number;
+      criticalIssues: number;
+    }>>>(
+      buildUrl(QUALITY_ENDPOINTS.ISSUES.TRENDS, params)
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // QUALITY MONITORING OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get list of quality monitoring configurations
+   */
+  async getQualityMonitoring(
+    page: number = 1,
+    limit: number = 20,
+    status?: string
+  ): Promise<CatalogApiResponse<{
+    monitors: QualityMonitoring[];
+    totalCount: number;
+  }>> {
+    const params = { page, limit, status };
+
+    const response = await axios.get<CatalogApiResponse<{
+      monitors: QualityMonitoring[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(QUALITY_ENDPOINTS.MONITORING.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create quality monitoring configuration
+   */
+  async createQualityMonitoring(
+    request: CreateQualityMonitoringRequest
+  ): Promise<CatalogApiResponse<QualityMonitoring>> {
+    const response = await axios.post<CatalogApiResponse<QualityMonitoring>>(
+      QUALITY_ENDPOINTS.MONITORING.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality monitoring by ID
+   */
+  async getQualityMonitoringById(id: string): Promise<CatalogApiResponse<QualityMonitoring>> {
+    const response = await axios.get<CatalogApiResponse<QualityMonitoring>>(
+      QUALITY_ENDPOINTS.MONITORING.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update quality monitoring
+   */
+  async updateQualityMonitoring(
+    id: string,
+    updates: Partial<CreateQualityMonitoringRequest>
+  ): Promise<CatalogApiResponse<QualityMonitoring>> {
+    const response = await axios.put<CatalogApiResponse<QualityMonitoring>>(
+      QUALITY_ENDPOINTS.MONITORING.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete quality monitoring
+   */
+  async deleteQualityMonitoring(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.MONITORING.DELETE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Start quality monitoring
+   */
+  async startQualityMonitoring(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.MONITORING.START(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Stop quality monitoring
+   */
+  async stopQualityMonitoring(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.MONITORING.STOP(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality monitoring status
+   */
+  async getQualityMonitoringStatus(id: string): Promise<CatalogApiResponse<{
+    status: string;
+    lastRun: Date;
+    nextRun: Date;
+    alertsTriggered: number;
+    issuesDetected: number;
+    performance: any;
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      status: string;
+      lastRun: Date;
+      nextRun: Date;
+      alertsTriggered: number;
+      issuesDetected: number;
+      performance: any;
+    }>>(
+      QUALITY_ENDPOINTS.MONITORING.STATUS(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality monitoring alerts
+   */
+  async getQualityMonitoringAlerts(
+    id: string,
+    limit: number = 50
+  ): Promise<CatalogApiResponse<any[]>> {
+    const params = { limit };
+
+    const response = await axios.get<CatalogApiResponse<any[]>>(
+      buildUrl(QUALITY_ENDPOINTS.MONITORING.ALERTS(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Configure quality monitoring
+   */
+  async configureQualityMonitoring(
+    id: string,
+    configuration: any
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.MONITORING.CONFIGURE(id),
+      configuration
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // QUALITY REPORTS OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get list of quality reports
+   */
+  async getQualityReportsList(
+    page: number = 1,
+    limit: number = 20,
+    type?: string,
+    status?: string
+  ): Promise<CatalogApiResponse<{
+    reports: QualityReport[];
+    totalCount: number;
+  }>> {
+    const params = { page, limit, type, status };
+
+    const response = await axios.get<CatalogApiResponse<{
+      reports: QualityReport[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(QUALITY_ENDPOINTS.REPORTS.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create quality report
+   */
+  async createQualityReport(
+    request: CreateQualityReportRequest
+  ): Promise<CatalogApiResponse<QualityReport>> {
+    const response = await axios.post<CatalogApiResponse<QualityReport>>(
+      QUALITY_ENDPOINTS.REPORTS.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality report by ID
+   */
+  async getQualityReportById(id: string): Promise<CatalogApiResponse<QualityReport>> {
+    const response = await axios.get<CatalogApiResponse<QualityReport>>(
+      QUALITY_ENDPOINTS.REPORTS.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Generate quality report
+   */
+  async generateQualityReport(
+    id: string,
+    format?: string[]
+  ): Promise<CatalogApiResponse<{ reportId: string; estimatedTime: number }>> {
+    const request = { format };
+
+    const response = await axios.post<CatalogApiResponse<{ reportId: string; estimatedTime: number }>>(
+      QUALITY_ENDPOINTS.REPORTS.GENERATE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Schedule quality report
+   */
+  async scheduleQualityReport(
+    id: string,
+    schedule: QualityScheduleConfig
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.REPORTS.SCHEDULE(id),
+      schedule
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Export quality report
+   */
+  async exportQualityReport(
+    id: string,
+    format: 'PDF' | 'EXCEL' | 'CSV'
+  ): Promise<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>> {
+    const request = { format };
+
+    const response = await axios.post<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>>(
+      QUALITY_ENDPOINTS.REPORTS.EXPORT(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Share quality report
+   */
+  async shareQualityReport(
+    id: string,
+    recipients: string[],
+    message?: string
+  ): Promise<CatalogApiResponse<void>> {
+    const request = { recipients, message };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      QUALITY_ENDPOINTS.REPORTS.SHARE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get quality report templates
+   */
+  async getQualityReportTemplates(): Promise<CatalogApiResponse<Array<{
+    id: string;
+    name: string;
+    description: string;
+    type: string;
+    template: any;
+  }>>> {
+    const response = await axios.get<CatalogApiResponse<Array<{
+      id: string;
+      name: string;
+      description: string;
+      type: string;
+      template: any;
+    }>>>(
+      QUALITY_ENDPOINTS.REPORTS.TEMPLATES
+    );
+
+    return response.data;
+  }
+}
+
+// ============================================================================
+// EXPORT SERVICE INSTANCE
+// ============================================================================
+
+export const catalogQualityService = new CatalogQualityService();
+export default catalogQualityService;

--- a/v15_enhanced_1/components/Advanced-Catalog/services/enterprise-catalog.service.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/services/enterprise-catalog.service.ts
@@ -1,0 +1,841 @@
+// ============================================================================
+// ENTERPRISE CATALOG SERVICE - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: enterprise_catalog_service.py
+// Core catalog operations, asset management, and enterprise features
+// ============================================================================
+
+import axios, { AxiosResponse } from 'axios';
+import { 
+  IntelligentDataAsset, 
+  CatalogApiResponse,
+  CatalogSearchRequest,
+  SearchFilter,
+  SortOption,
+  PaginationRequest,
+  AssetUsageMetrics,
+  DataQualityAssessment,
+  BusinessGlossaryTerm,
+  EnterpriseDataLineage
+} from '../types';
+import { 
+  ENTERPRISE_CATALOG_ENDPOINTS, 
+  API_CONFIG,
+  buildUrl,
+  buildPaginatedUrl 
+} from '../constants';
+
+// ============================================================================
+// BASE SERVICE CONFIGURATION
+// ============================================================================
+
+class BaseApiService {
+  protected baseURL: string;
+  protected timeout: number;
+  protected retryAttempts: number;
+  protected retryDelay: number;
+
+  constructor() {
+    this.baseURL = API_CONFIG.BASE_URL;
+    this.timeout = API_CONFIG.TIMEOUT;
+    this.retryAttempts = API_CONFIG.RETRY_ATTEMPTS;
+    this.retryDelay = API_CONFIG.RETRY_DELAY;
+    
+    // Configure axios defaults
+    axios.defaults.timeout = this.timeout;
+    this.setupInterceptors();
+  }
+
+  private setupInterceptors(): void {
+    // Request interceptor for auth and common headers
+    axios.interceptors.request.use(
+      (config) => {
+        const token = localStorage.getItem('auth_token');
+        if (token) {
+          config.headers.Authorization = `Bearer ${token}`;
+        }
+        config.headers['Content-Type'] = 'application/json';
+        config.headers['X-API-Version'] = API_CONFIG.VERSION;
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
+
+    // Response interceptor for error handling
+    axios.interceptors.response.use(
+      (response) => response,
+      async (error) => {
+        if (error.response?.status === 401) {
+          // Handle token refresh or redirect to login
+          localStorage.removeItem('auth_token');
+          window.location.href = '/login';
+        }
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  protected async retryRequest<T>(
+    requestFn: () => Promise<AxiosResponse<T>>,
+    attempts: number = this.retryAttempts
+  ): Promise<AxiosResponse<T>> {
+    try {
+      return await requestFn();
+    } catch (error) {
+      if (attempts > 1 && this.isRetryableError(error)) {
+        await this.delay(this.retryDelay);
+        return this.retryRequest(requestFn, attempts - 1);
+      }
+      throw error;
+    }
+  }
+
+  private isRetryableError(error: any): boolean {
+    return (
+      error.code === 'NETWORK_ERROR' ||
+      error.code === 'ECONNABORTED' ||
+      (error.response?.status >= 500 && error.response?.status <= 599)
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}
+
+// ============================================================================
+// ENTERPRISE CATALOG SERVICE INTERFACES
+// ============================================================================
+
+export interface AssetCreateRequest {
+  name: string;
+  displayName?: string;
+  description?: string;
+  assetType: string;
+  dataSource: {
+    id: string;
+    connectionString?: string;
+    location: string;
+  };
+  schema?: any;
+  columns?: any[];
+  tags?: string[];
+  classifications?: string[];
+  sensitivityLevel?: string;
+  owner?: string;
+  stewards?: string[];
+  metadata?: Record<string, any>;
+}
+
+export interface AssetUpdateRequest extends Partial<AssetCreateRequest> {
+  id: string;
+}
+
+export interface AssetBulkUpdateRequest {
+  assetIds: string[];
+  updates: Partial<AssetCreateRequest>;
+  strategy: 'MERGE' | 'REPLACE' | 'SELECTIVE';
+}
+
+export interface AssetSearchResponse {
+  assets: IntelligentDataAsset[];
+  totalCount: number;
+  facets?: any[];
+  suggestions?: string[];
+  relatedQueries?: string[];
+  searchMetadata: {
+    query: string;
+    executionTime: number;
+    searchType: string;
+    filters: SearchFilter[];
+  };
+}
+
+export interface AssetValidationResult {
+  isValid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+  suggestions: ValidationSuggestion[];
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+  code: string;
+  severity: 'ERROR' | 'WARNING' | 'INFO';
+}
+
+export interface ValidationWarning extends ValidationError {
+  canIgnore: boolean;
+  recommendation?: string;
+}
+
+export interface ValidationSuggestion {
+  field: string;
+  suggestion: string;
+  confidence: number;
+  category: string;
+}
+
+export interface EnterpriseMetrics {
+  totalAssets: number;
+  assetsByType: Record<string, number>;
+  assetsByStatus: Record<string, number>;
+  assetsBySensitivity: Record<string, number>;
+  qualityDistribution: Record<string, number>;
+  usageStatistics: {
+    totalViews: number;
+    totalDownloads: number;
+    activeUsers: number;
+    topAssets: Array<{ id: string; name: string; views: number }>;
+  };
+  recentActivities: Array<{
+    type: string;
+    assetId: string;
+    assetName: string;
+    userId: string;
+    timestamp: Date;
+  }>;
+  systemHealth: {
+    status: 'HEALTHY' | 'WARNING' | 'ERROR';
+    uptime: number;
+    performance: {
+      averageResponseTime: number;
+      successRate: number;
+      errorRate: number;
+    };
+  };
+}
+
+// ============================================================================
+// ENTERPRISE CATALOG SERVICE CLASS
+// ============================================================================
+
+export class EnterpriseCatalogService extends BaseApiService {
+  
+  // ============================================================================
+  // ASSET MANAGEMENT OPERATIONS
+  // ============================================================================
+
+  /**
+   * Retrieve paginated list of assets with filtering and sorting
+   */
+  async getAssets(
+    page: number = 1,
+    limit: number = 20,
+    filters?: SearchFilter[],
+    sortBy?: string,
+    sortOrder?: 'ASC' | 'DESC',
+    includeMetadata: boolean = true
+  ): Promise<CatalogApiResponse<AssetSearchResponse>> {
+    const params = {
+      page,
+      limit,
+      sortBy,
+      sortOrder,
+      includeMetadata,
+      ...(filters && { filters: JSON.stringify(filters) })
+    };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<AssetSearchResponse>>(
+        buildPaginatedUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.LIST, page, limit, params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create a new data asset
+   */
+  async createAsset(
+    assetData: AssetCreateRequest
+  ): Promise<CatalogApiResponse<IntelligentDataAsset>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<IntelligentDataAsset>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.CREATE,
+        assetData
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retrieve a specific asset by ID
+   */
+  async getAsset(
+    id: string,
+    includeLineage: boolean = false,
+    includeQuality: boolean = false,
+    includeUsage: boolean = false
+  ): Promise<CatalogApiResponse<IntelligentDataAsset>> {
+    const params = {
+      includeLineage,
+      includeQuality,
+      includeUsage
+    };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.GET(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update an existing asset
+   */
+  async updateAsset(
+    id: string,
+    updates: Partial<AssetCreateRequest>
+  ): Promise<CatalogApiResponse<IntelligentDataAsset>> {
+    const response = await this.retryRequest(() =>
+      axios.put<CatalogApiResponse<IntelligentDataAsset>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.UPDATE(id),
+        updates
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete an asset
+   */
+  async deleteAsset(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.delete<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.DELETE(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Bulk update multiple assets
+   */
+  async bulkUpdateAssets(
+    request: AssetBulkUpdateRequest
+  ): Promise<CatalogApiResponse<{ updated: number; failed: number; errors: any[] }>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<{ updated: number; failed: number; errors: any[] }>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.BULK_UPDATE,
+        request
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Bulk delete multiple assets
+   */
+  async bulkDeleteAssets(
+    assetIds: string[],
+    force: boolean = false
+  ): Promise<CatalogApiResponse<{ deleted: number; failed: number; errors: any[] }>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<{ deleted: number; failed: number; errors: any[] }>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.BULK_DELETE,
+        { assetIds, force }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Validate asset data before creation or update
+   */
+  async validateAsset(
+    assetData: AssetCreateRequest | AssetUpdateRequest
+  ): Promise<CatalogApiResponse<AssetValidationResult>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<AssetValidationResult>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.VALIDATE,
+        assetData
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // ASSET METADATA OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get asset schema information
+   */
+  async getAssetSchema(id: string): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.SCHEMA(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get asset columns with detailed information
+   */
+  async getAssetColumns(
+    id: string,
+    includeProfile: boolean = false,
+    includeQuality: boolean = false
+  ): Promise<CatalogApiResponse<any[]>> {
+    const params = { includeProfile, includeQuality };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.COLUMNS(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get comprehensive asset metadata
+   */
+  async getAssetMetadata(id: string): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.METADATA(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get asset relationships and dependencies
+   */
+  async getAssetRelationships(
+    id: string,
+    relationshipType?: string
+  ): Promise<CatalogApiResponse<any[]>> {
+    const params = relationshipType ? { type: relationshipType } : {};
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.RELATIONSHIPS(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // ASSET CLASSIFICATION & TAGGING
+  // ============================================================================
+
+  /**
+   * Get asset tags
+   */
+  async getAssetTags(id: string): Promise<CatalogApiResponse<string[]>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<string[]>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.TAGS(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Add tags to an asset
+   */
+  async addAssetTags(
+    id: string,
+    tags: string[]
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.TAGS(id),
+        { tags, action: 'ADD' }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Remove tags from an asset
+   */
+  async removeAssetTags(
+    id: string,
+    tags: string[]
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.TAGS(id),
+        { tags, action: 'REMOVE' }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get asset classifications
+   */
+  async getAssetClassifications(id: string): Promise<CatalogApiResponse<any[]>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any[]>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.CLASSIFICATIONS(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Apply classifications to an asset
+   */
+  async applyAssetClassifications(
+    id: string,
+    classifications: any[]
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.CLASSIFICATIONS(id),
+        { classifications }
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // ASSET QUALITY & USAGE
+  // ============================================================================
+
+  /**
+   * Get asset quality score and assessment
+   */
+  async getAssetQuality(id: string): Promise<CatalogApiResponse<DataQualityAssessment>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<DataQualityAssessment>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.QUALITY_SCORE(id)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get asset usage metrics and analytics
+   */
+  async getAssetUsage(
+    id: string,
+    period?: string,
+    granularity?: string
+  ): Promise<CatalogApiResponse<AssetUsageMetrics>> {
+    const params = { period, granularity };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<AssetUsageMetrics>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.USAGE_METRICS(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get asset lineage information
+   */
+  async getAssetLineage(
+    id: string,
+    direction?: 'UPSTREAM' | 'DOWNSTREAM' | 'BOTH',
+    depth?: number
+  ): Promise<CatalogApiResponse<EnterpriseDataLineage[]>> {
+    const params = { direction, depth };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<EnterpriseDataLineage[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.LINEAGE(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // ASSET RECOMMENDATIONS & DISCOVERY
+  // ============================================================================
+
+  /**
+   * Get asset recommendations for a user
+   */
+  async getAssetRecommendations(
+    id: string,
+    userId?: string,
+    limit: number = 10
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = { userId, limit };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.RECOMMENDATIONS(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Find similar assets
+   */
+  async getSimilarAssets(
+    id: string,
+    similarity_threshold: number = 0.7,
+    limit: number = 10
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = { similarity_threshold, limit };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.SIMILAR(id), params)
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // USER INTERACTION OPERATIONS
+  // ============================================================================
+
+  /**
+   * Add asset to user favorites
+   */
+  async addToFavorites(id: string, userId: string): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.FAVORITES(id),
+        { userId, action: 'ADD' }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Remove asset from user favorites
+   */
+  async removeFromFavorites(id: string, userId: string): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.FAVORITES(id),
+        { userId, action: 'REMOVE' }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Watch/subscribe to asset changes
+   */
+  async watchAsset(id: string, userId: string): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.WATCH(id),
+        { userId, action: 'WATCH' }
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Unwatch/unsubscribe from asset changes
+   */
+  async unwatchAsset(id: string, userId: string): Promise<CatalogApiResponse<void>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<void>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ASSETS.WATCH(id),
+        { userId, action: 'UNWATCH' }
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // ENTERPRISE FEATURES
+  // ============================================================================
+
+  /**
+   * Get enterprise dashboard data
+   */
+  async getEnterpriseDashboard(): Promise<CatalogApiResponse<EnterpriseMetrics>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<EnterpriseMetrics>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ENTERPRISE.DASHBOARD
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get system health status
+   */
+  async getSystemHealth(): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ENTERPRISE.HEALTH
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get enterprise metrics
+   */
+  async getEnterpriseMetrics(
+    period?: string,
+    groupBy?: string
+  ): Promise<CatalogApiResponse<any>> {
+    const params = { period, groupBy };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.ENTERPRISE.METRICS, params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Generate enterprise reports
+   */
+  async generateEnterpriseReport(
+    reportType: string,
+    parameters: any
+  ): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.post<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.ENTERPRISE.REPORTS,
+        { reportType, parameters }
+      )
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // CATALOG OVERVIEW OPERATIONS
+  // ============================================================================
+
+  /**
+   * Get catalog overview and statistics
+   */
+  async getCatalogOverview(): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.OVERVIEW
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get catalog statistics
+   */
+  async getCatalogStatistics(): Promise<CatalogApiResponse<any>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<any>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.STATISTICS
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get trending assets
+   */
+  async getTrendingAssets(
+    period: string = '7d',
+    limit: number = 10
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = { period, limit };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.TRENDING, params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get popular assets
+   */
+  async getPopularAssets(
+    period: string = '30d',
+    limit: number = 10
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = { period, limit };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.POPULAR, params)
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get featured assets
+   */
+  async getFeaturedAssets(): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.FEATURED
+      )
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get personalized recommendations for a user
+   */
+  async getPersonalizedRecommendations(
+    userId: string,
+    limit: number = 20
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = { userId, limit };
+
+    const response = await this.retryRequest(() =>
+      axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+        buildUrl(ENTERPRISE_CATALOG_ENDPOINTS.CATALOG.PERSONALIZED, params)
+      )
+    );
+
+    return response.data;
+  }
+}
+
+// ============================================================================
+// EXPORT SERVICE INSTANCE
+// ============================================================================
+
+export const enterpriseCatalogService = new EnterpriseCatalogService();
+export default enterpriseCatalogService;

--- a/v15_enhanced_1/components/Advanced-Catalog/services/index.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/services/index.ts
@@ -1,0 +1,419 @@
+// ============================================================================
+// ADVANCED CATALOG SERVICES INDEX - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Centralized export point for all catalog services
+// ============================================================================
+
+// Export individual service classes and instances
+export { 
+  EnterpriseCatalogService,
+  enterpriseCatalogService 
+} from './enterprise-catalog.service';
+
+export { 
+  SemanticSearchService,
+  semanticSearchService 
+} from './semantic-search.service';
+
+export { 
+  IntelligentDiscoveryService,
+  intelligentDiscoveryService 
+} from './intelligent-discovery.service';
+
+export { 
+  CatalogQualityService,
+  catalogQualityService 
+} from './catalog-quality.service';
+
+// Export service interfaces for type safety
+export type {
+  AssetCreateRequest,
+  AssetUpdateRequest,
+  AssetBulkUpdateRequest,
+  AssetSearchResponse,
+  AssetValidationResult,
+  EnterpriseMetrics
+} from './enterprise-catalog.service';
+
+export type {
+  BasicSearchRequest,
+  AdvancedSearchRequest,
+  SemanticSearchRequest,
+  FacetedSearchRequest,
+  NaturalLanguageSearchRequest,
+  SearchSuggestionRequest,
+  SearchPersonalizationRequest,
+  SearchAnalyticsRequest
+} from './semantic-search.service';
+
+export type {
+  CreateDiscoveryJobRequest,
+  DiscoveryJobUpdateRequest,
+  CreateDiscoveryConfigRequest,
+  CreateDiscoverySourceRequest,
+  DiscoveryJobExecutionRequest,
+  DiscoveryAnalyticsRequest,
+  IncrementalDiscoveryRequest
+} from './intelligent-discovery.service';
+
+export type {
+  CreateQualityAssessmentRequest,
+  CreateQualityRuleRequest,
+  CreateQualityDashboardRequest,
+  CreateQualityMonitoringRequest,
+  CreateQualityReportRequest,
+  QualityAnalyticsRequest,
+  QualityIssueUpdateRequest
+} from './catalog-quality.service';
+
+// ============================================================================
+// CENTRALIZED SERVICE REGISTRY
+// ============================================================================
+
+/**
+ * Centralized registry of all catalog services
+ * Provides easy access to all service instances
+ */
+export const catalogServices = {
+  enterpriseCatalog: enterpriseCatalogService,
+  semanticSearch: semanticSearchService,
+  intelligentDiscovery: intelligentDiscoveryService,
+  catalogQuality: catalogQualityService,
+} as const;
+
+/**
+ * Service types registry for type checking
+ */
+export type CatalogServiceRegistry = typeof catalogServices;
+
+/**
+ * Service names enum for type-safe service access
+ */
+export enum CatalogServiceNames {
+  ENTERPRISE_CATALOG = 'enterpriseCatalog',
+  SEMANTIC_SEARCH = 'semanticSearch',
+  INTELLIGENT_DISCOVERY = 'intelligentDiscovery',
+  CATALOG_QUALITY = 'catalogQuality',
+}
+
+// ============================================================================
+// SERVICE UTILITIES
+// ============================================================================
+
+/**
+ * Get a specific service by name with type safety
+ */
+export function getCatalogService<T extends keyof CatalogServiceRegistry>(
+  serviceName: T
+): CatalogServiceRegistry[T] {
+  return catalogServices[serviceName];
+}
+
+/**
+ * Check if a service is available
+ */
+export function isServiceAvailable(serviceName: keyof CatalogServiceRegistry): boolean {
+  return serviceName in catalogServices && catalogServices[serviceName] !== undefined;
+}
+
+/**
+ * Get all available service names
+ */
+export function getAvailableServices(): Array<keyof CatalogServiceRegistry> {
+  return Object.keys(catalogServices) as Array<keyof CatalogServiceRegistry>;
+}
+
+/**
+ * Service health check interface
+ */
+export interface ServiceHealthStatus {
+  serviceName: string;
+  status: 'healthy' | 'degraded' | 'unavailable';
+  lastChecked: Date;
+  responseTime?: number;
+  errors?: string[];
+}
+
+/**
+ * Perform health check on all services
+ */
+export async function performServiceHealthCheck(): Promise<ServiceHealthStatus[]> {
+  const healthChecks: ServiceHealthStatus[] = [];
+  
+  for (const [serviceName] of Object.entries(catalogServices)) {
+    const startTime = Date.now();
+    
+    try {
+      // Basic connectivity check - this would be implemented per service
+      // For now, we'll assume services are healthy if they exist
+      const responseTime = Date.now() - startTime;
+      
+      healthChecks.push({
+        serviceName,
+        status: 'healthy',
+        lastChecked: new Date(),
+        responseTime
+      });
+    } catch (error) {
+      healthChecks.push({
+        serviceName,
+        status: 'unavailable',
+        lastChecked: new Date(),
+        errors: [error instanceof Error ? error.message : 'Unknown error']
+      });
+    }
+  }
+  
+  return healthChecks;
+}
+
+// ============================================================================
+// SERVICE CONFIGURATION
+// ============================================================================
+
+/**
+ * Global service configuration interface
+ */
+export interface ServiceConfiguration {
+  timeout: number;
+  retryAttempts: number;
+  retryDelay: number;
+  enableLogging: boolean;
+  enableMetrics: boolean;
+  enableCaching: boolean;
+  cacheTimeout: number;
+}
+
+/**
+ * Default service configuration
+ */
+export const defaultServiceConfig: ServiceConfiguration = {
+  timeout: 30000,
+  retryAttempts: 3,
+  retryDelay: 1000,
+  enableLogging: true,
+  enableMetrics: true,
+  enableCaching: true,
+  cacheTimeout: 300000,
+};
+
+/**
+ * Service configuration registry
+ */
+let serviceConfig: ServiceConfiguration = { ...defaultServiceConfig };
+
+/**
+ * Update global service configuration
+ */
+export function updateServiceConfiguration(config: Partial<ServiceConfiguration>): void {
+  serviceConfig = { ...serviceConfig, ...config };
+}
+
+/**
+ * Get current service configuration
+ */
+export function getServiceConfiguration(): ServiceConfiguration {
+  return { ...serviceConfig };
+}
+
+// ============================================================================
+// SERVICE EVENTS
+// ============================================================================
+
+/**
+ * Service event types
+ */
+export enum ServiceEventType {
+  REQUEST_START = 'request_start',
+  REQUEST_SUCCESS = 'request_success',
+  REQUEST_ERROR = 'request_error',
+  REQUEST_TIMEOUT = 'request_timeout',
+  SERVICE_UNAVAILABLE = 'service_unavailable',
+}
+
+/**
+ * Service event interface
+ */
+export interface ServiceEvent {
+  type: ServiceEventType;
+  serviceName: string;
+  timestamp: Date;
+  duration?: number;
+  error?: Error;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Service event listener type
+ */
+export type ServiceEventListener = (event: ServiceEvent) => void;
+
+/**
+ * Service event manager
+ */
+class ServiceEventManager {
+  private listeners: Map<ServiceEventType, ServiceEventListener[]> = new Map();
+
+  /**
+   * Add event listener
+   */
+  addEventListener(type: ServiceEventType, listener: ServiceEventListener): void {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, []);
+    }
+    this.listeners.get(type)!.push(listener);
+  }
+
+  /**
+   * Remove event listener
+   */
+  removeEventListener(type: ServiceEventType, listener: ServiceEventListener): void {
+    const typeListeners = this.listeners.get(type);
+    if (typeListeners) {
+      const index = typeListeners.indexOf(listener);
+      if (index > -1) {
+        typeListeners.splice(index, 1);
+      }
+    }
+  }
+
+  /**
+   * Emit event
+   */
+  emit(event: ServiceEvent): void {
+    const typeListeners = this.listeners.get(event.type);
+    if (typeListeners) {
+      typeListeners.forEach(listener => {
+        try {
+          listener(event);
+        } catch (error) {
+          console.error('Error in service event listener:', error);
+        }
+      });
+    }
+  }
+
+  /**
+   * Clear all listeners
+   */
+  clearAllListeners(): void {
+    this.listeners.clear();
+  }
+}
+
+/**
+ * Global service event manager instance
+ */
+export const serviceEventManager = new ServiceEventManager();
+
+// ============================================================================
+// SERVICE METRICS
+// ============================================================================
+
+/**
+ * Service metrics interface
+ */
+export interface ServiceMetrics {
+  serviceName: string;
+  totalRequests: number;
+  successfulRequests: number;
+  failedRequests: number;
+  averageResponseTime: number;
+  lastRequestTime?: Date;
+  uptime: number;
+}
+
+/**
+ * Service metrics registry
+ */
+const serviceMetrics: Map<string, ServiceMetrics> = new Map();
+
+/**
+ * Initialize metrics for a service
+ */
+export function initializeServiceMetrics(serviceName: string): void {
+  serviceMetrics.set(serviceName, {
+    serviceName,
+    totalRequests: 0,
+    successfulRequests: 0,
+    failedRequests: 0,
+    averageResponseTime: 0,
+    uptime: Date.now(),
+  });
+}
+
+/**
+ * Update service metrics
+ */
+export function updateServiceMetrics(
+  serviceName: string,
+  success: boolean,
+  responseTime: number
+): void {
+  const metrics = serviceMetrics.get(serviceName);
+  if (metrics) {
+    metrics.totalRequests++;
+    metrics.lastRequestTime = new Date();
+    
+    if (success) {
+      metrics.successfulRequests++;
+    } else {
+      metrics.failedRequests++;
+    }
+    
+    // Update average response time
+    const totalTime = metrics.averageResponseTime * (metrics.totalRequests - 1) + responseTime;
+    metrics.averageResponseTime = totalTime / metrics.totalRequests;
+  }
+}
+
+/**
+ * Get metrics for a specific service
+ */
+export function getServiceMetrics(serviceName: string): ServiceMetrics | undefined {
+  return serviceMetrics.get(serviceName);
+}
+
+/**
+ * Get metrics for all services
+ */
+export function getAllServiceMetrics(): ServiceMetrics[] {
+  return Array.from(serviceMetrics.values());
+}
+
+/**
+ * Reset metrics for a service
+ */
+export function resetServiceMetrics(serviceName: string): void {
+  const metrics = serviceMetrics.get(serviceName);
+  if (metrics) {
+    metrics.totalRequests = 0;
+    metrics.successfulRequests = 0;
+    metrics.failedRequests = 0;
+    metrics.averageResponseTime = 0;
+    metrics.lastRequestTime = undefined;
+    metrics.uptime = Date.now();
+  }
+}
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
+
+/**
+ * Initialize all services and metrics
+ */
+export function initializeCatalogServices(): void {
+  // Initialize metrics for all services
+  Object.keys(catalogServices).forEach(serviceName => {
+    initializeServiceMetrics(serviceName);
+  });
+
+  console.log('Catalog services initialized successfully');
+}
+
+// Auto-initialize when module loads
+initializeCatalogServices();
+
+// Default export for convenience
+export default catalogServices;

--- a/v15_enhanced_1/components/Advanced-Catalog/services/intelligent-discovery.service.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/services/intelligent-discovery.service.ts
@@ -1,0 +1,1140 @@
+// ============================================================================
+// INTELLIGENT DISCOVERY SERVICE - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: intelligent_discovery_service.py
+// AI-powered data discovery, source scanning, and metadata extraction
+// ============================================================================
+
+import axios from 'axios';
+import { 
+  DiscoveryConfiguration,
+  DiscoveryJob,
+  DiscoverySource,
+  DiscoveredAsset,
+  IncrementalDiscoveryConfig,
+  DiscoveryDelta,
+  DataProfilingResult,
+  SchemaAnalysisResult,
+  CatalogApiResponse
+} from '../types';
+import { 
+  DISCOVERY_ENDPOINTS, 
+  buildUrl,
+  buildPaginatedUrl 
+} from '../constants';
+
+// ============================================================================
+// DISCOVERY SERVICE INTERFACES
+// ============================================================================
+
+export interface CreateDiscoveryJobRequest {
+  name: string;
+  description?: string;
+  configurationId: string;
+  sources?: string[];
+  schedule?: DiscoveryScheduleConfig;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
+  notifications?: NotificationConfig[];
+  metadata?: Record<string, any>;
+}
+
+export interface DiscoveryJobUpdateRequest {
+  name?: string;
+  description?: string;
+  configurationId?: string;
+  sources?: string[];
+  schedule?: DiscoveryScheduleConfig;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
+  notifications?: NotificationConfig[];
+  metadata?: Record<string, any>;
+}
+
+export interface DiscoveryScheduleConfig {
+  type: 'ONCE' | 'RECURRING';
+  cronExpression?: string;
+  startTime?: Date;
+  endTime?: Date;
+  timezone?: string;
+  enabled?: boolean;
+}
+
+export interface NotificationConfig {
+  type: 'EMAIL' | 'WEBHOOK' | 'SLACK';
+  recipients: string[];
+  events: string[];
+  template?: string;
+  settings?: Record<string, any>;
+}
+
+export interface CreateDiscoveryConfigRequest {
+  name: string;
+  description?: string;
+  sources: string[];
+  discoverySettings: DiscoverySettings;
+  aiConfiguration?: AIDiscoveryConfig;
+  qualitySettings?: QualityDiscoverySettings;
+  outputSettings?: OutputSettings;
+  metadata?: Record<string, any>;
+}
+
+export interface DiscoverySettings {
+  includeTypes: string[];
+  excludePatterns: string[];
+  maxDepth?: number;
+  samplingRate?: number;
+  timeoutMinutes?: number;
+  parallelism?: number;
+  enableSchemaDiscovery: boolean;
+  enableDataProfiling: boolean;
+  enableClassification: boolean;
+  enableLineageDiscovery: boolean;
+  enableQualityAssessment: boolean;
+}
+
+export interface AIDiscoveryConfig {
+  enabled: boolean;
+  classificationModel?: string;
+  embeddingModel?: string;
+  confidenceThreshold?: number;
+  enableNLP?: boolean;
+  enablePatternRecognition?: boolean;
+  enableAnomalyDetection?: boolean;
+  customModels?: Array<{
+    id: string;
+    type: string;
+    endpoint: string;
+    config: any;
+  }>;
+}
+
+export interface QualityDiscoverySettings {
+  enabled: boolean;
+  qualityRules: string[];
+  customRules?: Array<{
+    name: string;
+    expression: string;
+    severity: string;
+  }>;
+  scoreThreshold?: number;
+  generateRecommendations?: boolean;
+}
+
+export interface OutputSettings {
+  generateReports: boolean;
+  reportFormats: string[];
+  exportMetadata: boolean;
+  createDataCatalog: boolean;
+  updateExistingAssets: boolean;
+  notifyStakeholders: boolean;
+}
+
+export interface CreateDiscoverySourceRequest {
+  name: string;
+  type: 'DATABASE' | 'FILE_SYSTEM' | 'CLOUD_STORAGE' | 'API' | 'STREAMING' | 'DATA_WAREHOUSE' | 'DATA_LAKE' | 'NOSQL';
+  connectionString: string;
+  credentials: CredentialsConfig;
+  configuration: SourceConfiguration;
+  metadata?: Record<string, any>;
+}
+
+export interface CredentialsConfig {
+  type: 'USERNAME_PASSWORD' | 'TOKEN' | 'KEY_FILE' | 'IAM_ROLE' | 'SERVICE_PRINCIPAL';
+  username?: string;
+  password?: string;
+  token?: string;
+  keyFile?: string;
+  properties?: Record<string, string>;
+  encryptionKey?: string;
+}
+
+export interface SourceConfiguration {
+  includePatterns: string[];
+  excludePatterns: string[];
+  maxConnections?: number;
+  timeoutSeconds?: number;
+  retryAttempts?: number;
+  enableSsl?: boolean;
+  customProperties?: Record<string, any>;
+}
+
+export interface DiscoveryJobExecutionRequest {
+  sources?: string[];
+  overrideConfiguration?: Partial<DiscoverySettings>;
+  dryRun?: boolean;
+  priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
+  notifications?: NotificationConfig[];
+}
+
+export interface DiscoveryAnalyticsRequest {
+  startDate: Date;
+  endDate: Date;
+  jobIds?: string[];
+  sources?: string[];
+  metrics: string[];
+  groupBy?: string[];
+}
+
+export interface IncrementalDiscoveryRequest {
+  baselineJobId: string;
+  compareJobId?: string;
+  changeTypes: string[];
+  includeSchema?: boolean;
+  includeData?: boolean;
+  includeLineage?: boolean;
+}
+
+// ============================================================================
+// INTELLIGENT DISCOVERY SERVICE CLASS
+// ============================================================================
+
+export class IntelligentDiscoveryService {
+
+  // ============================================================================
+  // DISCOVERY JOB MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get list of discovery jobs with filtering and pagination
+   */
+  async getDiscoveryJobs(
+    page: number = 1,
+    limit: number = 20,
+    status?: string,
+    configurationId?: string,
+    sortBy?: string,
+    sortOrder?: 'ASC' | 'DESC'
+  ): Promise<CatalogApiResponse<{
+    jobs: DiscoveryJob[];
+    totalCount: number;
+    pagination: any;
+  }>> {
+    const params = {
+      page,
+      limit,
+      status,
+      configurationId,
+      sortBy,
+      sortOrder
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      jobs: DiscoveryJob[];
+      totalCount: number;
+      pagination: any;
+    }>>(
+      buildPaginatedUrl(DISCOVERY_ENDPOINTS.JOBS.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create a new discovery job
+   */
+  async createDiscoveryJob(
+    request: CreateDiscoveryJobRequest
+  ): Promise<CatalogApiResponse<DiscoveryJob>> {
+    const response = await axios.post<CatalogApiResponse<DiscoveryJob>>(
+      DISCOVERY_ENDPOINTS.JOBS.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery job by ID
+   */
+  async getDiscoveryJob(
+    id: string,
+    includeResults: boolean = false,
+    includeLogs: boolean = false
+  ): Promise<CatalogApiResponse<DiscoveryJob>> {
+    const params = {
+      includeResults,
+      includeLogs
+    };
+
+    const response = await axios.get<CatalogApiResponse<DiscoveryJob>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.GET(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update discovery job
+   */
+  async updateDiscoveryJob(
+    id: string,
+    updates: DiscoveryJobUpdateRequest
+  ): Promise<CatalogApiResponse<DiscoveryJob>> {
+    const response = await axios.put<CatalogApiResponse<DiscoveryJob>>(
+      DISCOVERY_ENDPOINTS.JOBS.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete discovery job
+   */
+  async deleteDiscoveryJob(
+    id: string,
+    force: boolean = false
+  ): Promise<CatalogApiResponse<void>> {
+    const params = { force };
+
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.DELETE(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Start discovery job execution
+   */
+  async startDiscoveryJob(
+    id: string,
+    request?: DiscoveryJobExecutionRequest
+  ): Promise<CatalogApiResponse<{ executionId: string; estimatedDuration: number }>> {
+    const response = await axios.post<CatalogApiResponse<{ executionId: string; estimatedDuration: number }>>(
+      DISCOVERY_ENDPOINTS.JOBS.START(id),
+      request || {}
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Stop discovery job execution
+   */
+  async stopDiscoveryJob(
+    id: string,
+    graceful: boolean = true
+  ): Promise<CatalogApiResponse<void>> {
+    const params = { graceful };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.STOP(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Pause discovery job execution
+   */
+  async pauseDiscoveryJob(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      DISCOVERY_ENDPOINTS.JOBS.PAUSE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Resume discovery job execution
+   */
+  async resumeDiscoveryJob(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      DISCOVERY_ENDPOINTS.JOBS.RESUME(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery job status and progress
+   */
+  async getDiscoveryJobStatus(id: string): Promise<CatalogApiResponse<{
+    status: string;
+    progress: any;
+    currentPhase: string;
+    startTime: Date;
+    duration: number;
+    estimatedCompletion?: Date;
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      status: string;
+      progress: any;
+      currentPhase: string;
+      startTime: Date;
+      duration: number;
+      estimatedCompletion?: Date;
+    }>>(
+      DISCOVERY_ENDPOINTS.JOBS.STATUS(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery job execution progress
+   */
+  async getDiscoveryJobProgress(id: string): Promise<CatalogApiResponse<{
+    totalSteps: number;
+    completedSteps: number;
+    currentStep: string;
+    percentage: number;
+    phaseProgress: any[];
+    performance: any;
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      totalSteps: number;
+      completedSteps: number;
+      currentStep: string;
+      percentage: number;
+      phaseProgress: any[];
+      performance: any;
+    }>>(
+      DISCOVERY_ENDPOINTS.JOBS.PROGRESS(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery job results
+   */
+  async getDiscoveryJobResults(
+    id: string,
+    includeAssets: boolean = true,
+    includeStatistics: boolean = true
+  ): Promise<CatalogApiResponse<{
+    results: any;
+    discoveredAssets: DiscoveredAsset[];
+    statistics: any;
+    summary: any;
+  }>> {
+    const params = {
+      includeAssets,
+      includeStatistics
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      results: any;
+      discoveredAssets: DiscoveredAsset[];
+      statistics: any;
+      summary: any;
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.RESULTS(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery job execution logs
+   */
+  async getDiscoveryJobLogs(
+    id: string,
+    level?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
+    startTime?: Date,
+    endTime?: Date,
+    limit: number = 1000
+  ): Promise<CatalogApiResponse<Array<{
+    timestamp: Date;
+    level: string;
+    message: string;
+    phase?: string;
+    metadata?: any;
+  }>>> {
+    const params = {
+      level,
+      startTime: startTime?.toISOString(),
+      endTime: endTime?.toISOString(),
+      limit
+    };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      timestamp: Date;
+      level: string;
+      message: string;
+      phase?: string;
+      metadata?: any;
+    }>>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.LOGS(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Cancel discovery job execution
+   */
+  async cancelDiscoveryJob(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.post<CatalogApiResponse<void>>(
+      DISCOVERY_ENDPOINTS.JOBS.CANCEL(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Retry failed discovery job
+   */
+  async retryDiscoveryJob(
+    id: string,
+    retryFailedOnly: boolean = true
+  ): Promise<CatalogApiResponse<{ newJobId: string }>> {
+    const params = { retryFailedOnly };
+
+    const response = await axios.post<CatalogApiResponse<{ newJobId: string }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.JOBS.RETRY(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Clone discovery job
+   */
+  async cloneDiscoveryJob(
+    id: string,
+    newName: string,
+    modifications?: Partial<CreateDiscoveryJobRequest>
+  ): Promise<CatalogApiResponse<DiscoveryJob>> {
+    const request = {
+      newName,
+      modifications
+    };
+
+    const response = await axios.post<CatalogApiResponse<DiscoveryJob>>(
+      DISCOVERY_ENDPOINTS.JOBS.CLONE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Export discovery job results
+   */
+  async exportDiscoveryJobResults(
+    id: string,
+    format: 'CSV' | 'EXCEL' | 'JSON' | 'PDF',
+    includeAssets: boolean = true,
+    includeMetadata: boolean = true
+  ): Promise<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>> {
+    const request = {
+      format,
+      includeAssets,
+      includeMetadata
+    };
+
+    const response = await axios.post<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>>(
+      DISCOVERY_ENDPOINTS.JOBS.EXPORT(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // DISCOVERY CONFIGURATION MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get list of discovery configurations
+   */
+  async getDiscoveryConfigurations(
+    page: number = 1,
+    limit: number = 20,
+    search?: string
+  ): Promise<CatalogApiResponse<{
+    configurations: DiscoveryConfiguration[];
+    totalCount: number;
+  }>> {
+    const params = { page, limit, search };
+
+    const response = await axios.get<CatalogApiResponse<{
+      configurations: DiscoveryConfiguration[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(DISCOVERY_ENDPOINTS.CONFIGURATIONS.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create new discovery configuration
+   */
+  async createDiscoveryConfiguration(
+    request: CreateDiscoveryConfigRequest
+  ): Promise<CatalogApiResponse<DiscoveryConfiguration>> {
+    const response = await axios.post<CatalogApiResponse<DiscoveryConfiguration>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery configuration by ID
+   */
+  async getDiscoveryConfiguration(id: string): Promise<CatalogApiResponse<DiscoveryConfiguration>> {
+    const response = await axios.get<CatalogApiResponse<DiscoveryConfiguration>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update discovery configuration
+   */
+  async updateDiscoveryConfiguration(
+    id: string,
+    updates: Partial<CreateDiscoveryConfigRequest>
+  ): Promise<CatalogApiResponse<DiscoveryConfiguration>> {
+    const response = await axios.put<CatalogApiResponse<DiscoveryConfiguration>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete discovery configuration
+   */
+  async deleteDiscoveryConfiguration(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.DELETE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Validate discovery configuration
+   */
+  async validateDiscoveryConfiguration(
+    config: CreateDiscoveryConfigRequest
+  ): Promise<CatalogApiResponse<{
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+    suggestions: string[];
+  }>> {
+    const response = await axios.post<CatalogApiResponse<{
+      valid: boolean;
+      errors: string[];
+      warnings: string[];
+      suggestions: string[];
+    }>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.VALIDATE,
+      config
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery configuration templates
+   */
+  async getDiscoveryConfigurationTemplates(): Promise<CatalogApiResponse<Array<{
+    id: string;
+    name: string;
+    description: string;
+    category: string;
+    template: Partial<CreateDiscoveryConfigRequest>;
+  }>>> {
+    const response = await axios.get<CatalogApiResponse<Array<{
+      id: string;
+      name: string;
+      description: string;
+      category: string;
+      template: Partial<CreateDiscoveryConfigRequest>;
+    }>>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.TEMPLATES
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Duplicate discovery configuration
+   */
+  async duplicateDiscoveryConfiguration(
+    id: string,
+    newName: string
+  ): Promise<CatalogApiResponse<DiscoveryConfiguration>> {
+    const request = { newName };
+
+    const response = await axios.post<CatalogApiResponse<DiscoveryConfiguration>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.DUPLICATE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Test discovery configuration
+   */
+  async testDiscoveryConfiguration(
+    id: string,
+    testSources?: string[]
+  ): Promise<CatalogApiResponse<{
+    success: boolean;
+    results: any[];
+    errors: string[];
+    performance: any;
+  }>> {
+    const request = { testSources };
+
+    const response = await axios.post<CatalogApiResponse<{
+      success: boolean;
+      results: any[];
+      errors: string[];
+      performance: any;
+    }>>(
+      DISCOVERY_ENDPOINTS.CONFIGURATIONS.TEST(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // DISCOVERY SOURCE MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get list of discovery sources
+   */
+  async getDiscoverySources(
+    page: number = 1,
+    limit: number = 20,
+    type?: string,
+    status?: string
+  ): Promise<CatalogApiResponse<{
+    sources: DiscoverySource[];
+    totalCount: number;
+  }>> {
+    const params = { page, limit, type, status };
+
+    const response = await axios.get<CatalogApiResponse<{
+      sources: DiscoverySource[];
+      totalCount: number;
+    }>>(
+      buildPaginatedUrl(DISCOVERY_ENDPOINTS.SOURCES.LIST, page, limit, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create new discovery source
+   */
+  async createDiscoverySource(
+    request: CreateDiscoverySourceRequest
+  ): Promise<CatalogApiResponse<DiscoverySource>> {
+    const response = await axios.post<CatalogApiResponse<DiscoverySource>>(
+      DISCOVERY_ENDPOINTS.SOURCES.CREATE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery source by ID
+   */
+  async getDiscoverySource(id: string): Promise<CatalogApiResponse<DiscoverySource>> {
+    const response = await axios.get<CatalogApiResponse<DiscoverySource>>(
+      DISCOVERY_ENDPOINTS.SOURCES.GET(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update discovery source
+   */
+  async updateDiscoverySource(
+    id: string,
+    updates: Partial<CreateDiscoverySourceRequest>
+  ): Promise<CatalogApiResponse<DiscoverySource>> {
+    const response = await axios.put<CatalogApiResponse<DiscoverySource>>(
+      DISCOVERY_ENDPOINTS.SOURCES.UPDATE(id),
+      updates
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Delete discovery source
+   */
+  async deleteDiscoverySource(id: string): Promise<CatalogApiResponse<void>> {
+    const response = await axios.delete<CatalogApiResponse<void>>(
+      DISCOVERY_ENDPOINTS.SOURCES.DELETE(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Test discovery source connection
+   */
+  async testDiscoverySourceConnection(id: string): Promise<CatalogApiResponse<{
+    success: boolean;
+    responseTime: number;
+    message: string;
+    details?: any;
+  }>> {
+    const response = await axios.post<CatalogApiResponse<{
+      success: boolean;
+      responseTime: number;
+      message: string;
+      details?: any;
+    }>>(
+      DISCOVERY_ENDPOINTS.SOURCES.TEST_CONNECTION(id)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Scan discovery source for available assets
+   */
+  async scanDiscoverySource(
+    id: string,
+    preview: boolean = false,
+    maxResults: number = 100
+  ): Promise<CatalogApiResponse<{
+    assets: any[];
+    totalCount: number;
+    scanTime: number;
+  }>> {
+    const params = { preview, maxResults };
+
+    const response = await axios.post<CatalogApiResponse<{
+      assets: any[];
+      totalCount: number;
+      scanTime: number;
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.SOURCES.SCAN(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Preview discovery source data
+   */
+  async previewDiscoverySource(
+    id: string,
+    assetPath?: string,
+    sampleSize: number = 10
+  ): Promise<CatalogApiResponse<{
+    schema: any;
+    sampleData: any[];
+    statistics: any;
+  }>> {
+    const params = { assetPath, sampleSize };
+
+    const response = await axios.get<CatalogApiResponse<{
+      schema: any;
+      sampleData: any[];
+      statistics: any;
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.SOURCES.PREVIEW(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery source schema
+   */
+  async getDiscoverySourceSchema(
+    id: string,
+    includeColumns: boolean = true
+  ): Promise<CatalogApiResponse<any>> {
+    const params = { includeColumns };
+
+    const response = await axios.get<CatalogApiResponse<any>>(
+      buildUrl(DISCOVERY_ENDPOINTS.SOURCES.SCHEMA(id), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery source statistics
+   */
+  async getDiscoverySourceStatistics(id: string): Promise<CatalogApiResponse<{
+    totalAssets: number;
+    assetsByType: Record<string, number>;
+    dataSize: string;
+    lastScanned: Date;
+    averageScanTime: number;
+    successRate: number;
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      totalAssets: number;
+      assetsByType: Record<string, number>;
+      dataSize: string;
+      lastScanned: Date;
+      averageScanTime: number;
+      successRate: number;
+    }>>(
+      DISCOVERY_ENDPOINTS.SOURCES.STATISTICS(id)
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // INCREMENTAL DISCOVERY
+  // ============================================================================
+
+  /**
+   * Get incremental discovery configurations
+   */
+  async getIncrementalDiscoveryConfigs(): Promise<CatalogApiResponse<IncrementalDiscoveryConfig[]>> {
+    const response = await axios.get<CatalogApiResponse<IncrementalDiscoveryConfig[]>>(
+      DISCOVERY_ENDPOINTS.INCREMENTAL.LIST
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create incremental discovery configuration
+   */
+  async createIncrementalDiscoveryConfig(
+    config: Omit<IncrementalDiscoveryConfig, 'id'>
+  ): Promise<CatalogApiResponse<IncrementalDiscoveryConfig>> {
+    const response = await axios.post<CatalogApiResponse<IncrementalDiscoveryConfig>>(
+      DISCOVERY_ENDPOINTS.INCREMENTAL.CREATE,
+      config
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get incremental discovery changes
+   */
+  async getIncrementalDiscoveryChanges(
+    id: string,
+    request: IncrementalDiscoveryRequest
+  ): Promise<CatalogApiResponse<DiscoveryDelta>> {
+    const response = await axios.post<CatalogApiResponse<DiscoveryDelta>>(
+      DISCOVERY_ENDPOINTS.INCREMENTAL.CHANGES(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Sync incremental discovery changes
+   */
+  async syncIncrementalDiscovery(
+    id: string,
+    changes: string[],
+    applyAutomatically: boolean = false
+  ): Promise<CatalogApiResponse<{
+    syncedChanges: number;
+    skippedChanges: number;
+    errors: string[];
+  }>> {
+    const request = {
+      changes,
+      applyAutomatically
+    };
+
+    const response = await axios.post<CatalogApiResponse<{
+      syncedChanges: number;
+      skippedChanges: number;
+      errors: string[];
+    }>>(
+      DISCOVERY_ENDPOINTS.INCREMENTAL.SYNC(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Create baseline for incremental discovery
+   */
+  async createIncrementalBaseline(
+    id: string,
+    jobId: string
+  ): Promise<CatalogApiResponse<{ baselineId: string }>> {
+    const request = { jobId };
+
+    const response = await axios.post<CatalogApiResponse<{ baselineId: string }>>(
+      DISCOVERY_ENDPOINTS.INCREMENTAL.BASELINE(id),
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // DISCOVERY ANALYTICS
+  // ============================================================================
+
+  /**
+   * Get discovery analytics overview
+   */
+  async getDiscoveryAnalyticsOverview(
+    startDate: Date,
+    endDate: Date
+  ): Promise<CatalogApiResponse<{
+    totalJobs: number;
+    successfulJobs: number;
+    failedJobs: number;
+    averageExecutionTime: number;
+    totalAssetsDiscovered: number;
+    topSources: any[];
+    performanceTrends: any[];
+  }>> {
+    const params = {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString()
+    };
+
+    const response = await axios.get<CatalogApiResponse<{
+      totalJobs: number;
+      successfulJobs: number;
+      failedJobs: number;
+      averageExecutionTime: number;
+      totalAssetsDiscovered: number;
+      topSources: any[];
+      performanceTrends: any[];
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.ANALYTICS.OVERVIEW, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery performance analytics
+   */
+  async getDiscoveryPerformanceAnalytics(
+    request: DiscoveryAnalyticsRequest
+  ): Promise<CatalogApiResponse<any>> {
+    const response = await axios.post<CatalogApiResponse<any>>(
+      DISCOVERY_ENDPOINTS.ANALYTICS.PERFORMANCE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery trend analytics
+   */
+  async getDiscoveryTrendAnalytics(
+    period: string = '30d',
+    granularity: 'HOUR' | 'DAY' | 'WEEK' = 'DAY'
+  ): Promise<CatalogApiResponse<any>> {
+    const params = { period, granularity };
+
+    const response = await axios.get<CatalogApiResponse<any>>(
+      buildUrl(DISCOVERY_ENDPOINTS.ANALYTICS.TRENDS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery success rate analytics
+   */
+  async getDiscoverySuccessRateAnalytics(
+    period: string = '30d'
+  ): Promise<CatalogApiResponse<{
+    overallSuccessRate: number;
+    successRateBySource: any[];
+    successRateByConfiguration: any[];
+    trendData: any[];
+  }>> {
+    const params = { period };
+
+    const response = await axios.get<CatalogApiResponse<{
+      overallSuccessRate: number;
+      successRateBySource: any[];
+      successRateByConfiguration: any[];
+      trendData: any[];
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.ANALYTICS.SUCCESS_RATE, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery error analysis
+   */
+  async getDiscoveryErrorAnalysis(
+    period: string = '30d'
+  ): Promise<CatalogApiResponse<{
+    totalErrors: number;
+    errorsByType: any[];
+    errorsBySource: any[];
+    commonErrors: any[];
+    resolutionSuggestions: any[];
+  }>> {
+    const params = { period };
+
+    const response = await axios.get<CatalogApiResponse<{
+      totalErrors: number;
+      errorsByType: any[];
+      errorsBySource: any[];
+      commonErrors: any[];
+      resolutionSuggestions: any[];
+    }>>(
+      buildUrl(DISCOVERY_ENDPOINTS.ANALYTICS.ERROR_ANALYSIS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get discovery optimization recommendations
+   */
+  async getDiscoveryOptimizationRecommendations(): Promise<CatalogApiResponse<Array<{
+    type: string;
+    title: string;
+    description: string;
+    impact: 'LOW' | 'MEDIUM' | 'HIGH';
+    effort: 'LOW' | 'MEDIUM' | 'HIGH';
+    category: string;
+    implementation: string;
+  }>>> {
+    const response = await axios.get<CatalogApiResponse<Array<{
+      type: string;
+      title: string;
+      description: string;
+      impact: 'LOW' | 'MEDIUM' | 'HIGH';
+      effort: 'LOW' | 'MEDIUM' | 'HIGH';
+      category: string;
+      implementation: string;
+    }>>>(
+      DISCOVERY_ENDPOINTS.ANALYTICS.RECOMMENDATIONS
+    );
+
+    return response.data;
+  }
+}
+
+// ============================================================================
+// EXPORT SERVICE INSTANCE
+// ============================================================================
+
+export const intelligentDiscoveryService = new IntelligentDiscoveryService();
+export default intelligentDiscoveryService;

--- a/v15_enhanced_1/components/Advanced-Catalog/services/semantic-search.service.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/services/semantic-search.service.ts
@@ -1,0 +1,815 @@
+// ============================================================================
+// SEMANTIC SEARCH SERVICE - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: semantic_search_service.py
+// Advanced search capabilities, natural language processing, and personalization
+// ============================================================================
+
+import axios from 'axios';
+import { 
+  SearchRequest,
+  SearchResponse,
+  NaturalLanguageQuery,
+  SearchPersonalization,
+  SearchAnalytics,
+  SemanticSearchEngine,
+  UnifiedSearchInterface,
+  SearchAutoComplete,
+  CatalogApiResponse,
+  IntelligentDataAsset,
+  BusinessGlossaryTerm
+} from '../types';
+import { 
+  SEARCH_ENDPOINTS, 
+  buildUrl,
+  buildPaginatedUrl 
+} from '../constants';
+
+// ============================================================================
+// SEARCH SERVICE INTERFACES
+// ============================================================================
+
+export interface BasicSearchRequest {
+  query: string;
+  searchType?: 'KEYWORD' | 'SEMANTIC' | 'NATURAL_LANGUAGE' | 'FACETED' | 'FUZZY' | 'BOOLEAN';
+  scope?: 'ALL' | 'ASSETS' | 'GLOSSARY' | 'LINEAGE' | 'QUALITY' | 'DOCUMENTATION';
+  filters?: Array<{
+    field: string;
+    operator: string;
+    value: any;
+  }>;
+  facets?: string[];
+  sort?: Array<{
+    field: string;
+    order: 'ASC' | 'DESC';
+  }>;
+  pagination?: {
+    page: number;
+    size: number;
+  };
+  highlighting?: {
+    enabled: boolean;
+    fields: string[];
+    fragmentSize?: number;
+  };
+  personalization?: {
+    userId?: string;
+    preferences?: any;
+  };
+}
+
+export interface AdvancedSearchRequest extends BasicSearchRequest {
+  aggregations?: Array<{
+    field: string;
+    type: 'TERMS' | 'RANGE' | 'DATE_HISTOGRAM';
+    size?: number;
+  }>;
+  suggestions?: {
+    enabled: boolean;
+    count?: number;
+  };
+  similarityThreshold?: number;
+  boostFields?: Record<string, number>;
+  customQuery?: any;
+}
+
+export interface SemanticSearchRequest {
+  query: string;
+  embeddingModel?: string;
+  similarityThreshold?: number;
+  maxResults?: number;
+  includeScore?: boolean;
+  contextFilters?: any[];
+  semanticExpansion?: boolean;
+}
+
+export interface FacetedSearchRequest extends BasicSearchRequest {
+  facetConfiguration?: {
+    minCount?: number;
+    maxTerms?: number;
+    includeEmpty?: boolean;
+    sortBy?: 'COUNT' | 'TERM';
+  };
+  drillDown?: Array<{
+    facet: string;
+    values: string[];
+  }>;
+}
+
+export interface NaturalLanguageSearchRequest {
+  naturalLanguageQuery: string;
+  intentRecognition?: boolean;
+  entityExtraction?: boolean;
+  queryExpansion?: boolean;
+  confidence?: number;
+  fallbackToKeyword?: boolean;
+  language?: string;
+}
+
+export interface SearchSuggestionRequest {
+  partialQuery: string;
+  maxSuggestions?: number;
+  suggestionTypes?: string[];
+  context?: any;
+  personalized?: boolean;
+  userId?: string;
+}
+
+export interface SearchPersonalizationRequest {
+  userId: string;
+  searchHistory?: boolean;
+  userPreferences?: boolean;
+  collaborativeFiltering?: boolean;
+  contentBasedRecommendations?: boolean;
+  behaviorAnalysis?: boolean;
+}
+
+export interface SearchAnalyticsRequest {
+  startDate: Date;
+  endDate: Date;
+  granularity?: 'HOUR' | 'DAY' | 'WEEK' | 'MONTH';
+  metrics?: string[];
+  groupBy?: string[];
+  filters?: any[];
+}
+
+// ============================================================================
+// SEMANTIC SEARCH SERVICE CLASS
+// ============================================================================
+
+export class SemanticSearchService {
+  private baseURL: string;
+
+  constructor() {
+    this.baseURL = SEARCH_ENDPOINTS.SEARCH.QUERY;
+  }
+
+  // ============================================================================
+  // BASIC SEARCH OPERATIONS
+  // ============================================================================
+
+  /**
+   * Perform a basic search with keyword matching
+   */
+  async search(request: BasicSearchRequest): Promise<CatalogApiResponse<SearchResponse>> {
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.QUERY,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Perform semantic search using vector embeddings
+   */
+  async semanticSearch(request: SemanticSearchRequest): Promise<CatalogApiResponse<SearchResponse>> {
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.SEMANTIC,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Perform advanced search with complex queries and aggregations
+   */
+  async advancedSearch(request: AdvancedSearchRequest): Promise<CatalogApiResponse<SearchResponse>> {
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.ADVANCED,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Perform faceted search with category-based filtering
+   */
+  async facetedSearch(request: FacetedSearchRequest): Promise<CatalogApiResponse<SearchResponse>> {
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.FACETED,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Process natural language queries with intent recognition
+   */
+  async naturalLanguageSearch(
+    request: NaturalLanguageSearchRequest
+  ): Promise<CatalogApiResponse<SearchResponse & { processedQuery: NaturalLanguageQuery }>> {
+    const response = await axios.post<CatalogApiResponse<SearchResponse & { processedQuery: NaturalLanguageQuery }>>(
+      SEARCH_ENDPOINTS.SEARCH.NATURAL_LANGUAGE,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Find similar assets based on content similarity
+   */
+  async similaritySearch(
+    assetId: string,
+    similarityThreshold: number = 0.7,
+    maxResults: number = 10,
+    excludeSelf: boolean = true
+  ): Promise<CatalogApiResponse<IntelligentDataAsset[]>> {
+    const params = {
+      assetId,
+      similarityThreshold,
+      maxResults,
+      excludeSelf
+    };
+
+    const response = await axios.get<CatalogApiResponse<IntelligentDataAsset[]>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.SIMILARITY, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Perform fuzzy search with approximate matching
+   */
+  async fuzzySearch(
+    query: string,
+    fuzziness: number = 1,
+    prefixLength: number = 0,
+    maxExpansions: number = 50
+  ): Promise<CatalogApiResponse<SearchResponse>> {
+    const request = {
+      query,
+      fuzziness,
+      prefixLength,
+      maxExpansions
+    };
+
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.FUZZY,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Perform boolean search with logical operators
+   */
+  async booleanSearch(
+    booleanQuery: string,
+    defaultOperator: 'AND' | 'OR' = 'AND'
+  ): Promise<CatalogApiResponse<SearchResponse>> {
+    const request = {
+      query: booleanQuery,
+      defaultOperator
+    };
+
+    const response = await axios.post<CatalogApiResponse<SearchResponse>>(
+      SEARCH_ENDPOINTS.SEARCH.BOOLEAN,
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // SEARCH SUGGESTIONS & AUTOCOMPLETE
+  // ============================================================================
+
+  /**
+   * Get search suggestions based on partial query
+   */
+  async getSuggestions(request: SearchSuggestionRequest): Promise<CatalogApiResponse<string[]>> {
+    const response = await axios.post<CatalogApiResponse<string[]>>(
+      SEARCH_ENDPOINTS.SEARCH.SUGGEST,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get autocomplete suggestions for search as user types
+   */
+  async getAutocompleteSuggestions(
+    partialQuery: string,
+    maxSuggestions: number = 10,
+    includeHighlighting: boolean = true,
+    userId?: string
+  ): Promise<CatalogApiResponse<SearchAutoComplete>> {
+    const params = {
+      q: partialQuery,
+      max: maxSuggestions,
+      highlight: includeHighlighting,
+      ...(userId && { userId })
+    };
+
+    const response = await axios.get<CatalogApiResponse<SearchAutoComplete>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.AUTOCOMPLETE, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get query corrections and spell-check suggestions
+   */
+  async getQueryCorrections(
+    query: string,
+    maxCorrections: number = 5
+  ): Promise<CatalogApiResponse<{ original: string; suggestions: string[]; confidence: number[] }>> {
+    const params = {
+      q: query,
+      max: maxCorrections
+    };
+
+    const response = await axios.get<CatalogApiResponse<{ original: string; suggestions: string[]; confidence: number[] }>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.CORRECTIONS, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get related queries based on search history and patterns
+   */
+  async getRelatedQueries(
+    query: string,
+    maxQueries: number = 5,
+    userId?: string
+  ): Promise<CatalogApiResponse<string[]>> {
+    const params = {
+      q: query,
+      max: maxQueries,
+      ...(userId && { userId })
+    };
+
+    const response = await axios.get<CatalogApiResponse<string[]>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.RELATED, params)
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // TRENDING & POPULAR SEARCHES
+  // ============================================================================
+
+  /**
+   * Get trending search queries
+   */
+  async getTrendingSearches(
+    period: string = '24h',
+    limit: number = 10,
+    category?: string
+  ): Promise<CatalogApiResponse<Array<{ query: string; count: number; trend: number }>>> {
+    const params = {
+      period,
+      limit,
+      ...(category && { category })
+    };
+
+    const response = await axios.get<CatalogApiResponse<Array<{ query: string; count: number; trend: number }>>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.TRENDING, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get popular search queries
+   */
+  async getPopularSearches(
+    period: string = '7d',
+    limit: number = 10,
+    userSegment?: string
+  ): Promise<CatalogApiResponse<Array<{ query: string; count: number; users: number }>>> {
+    const params = {
+      period,
+      limit,
+      ...(userSegment && { segment: userSegment })
+    };
+
+    const response = await axios.get<CatalogApiResponse<Array<{ query: string; count: number; users: number }>>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.POPULAR, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get recent searches for a user
+   */
+  async getRecentSearches(
+    userId: string,
+    limit: number = 20,
+    includeFailed: boolean = false
+  ): Promise<CatalogApiResponse<Array<{ query: string; timestamp: Date; results: number }>>> {
+    const params = {
+      userId,
+      limit,
+      includeFailed
+    };
+
+    const response = await axios.get<CatalogApiResponse<Array<{ query: string; timestamp: Date; results: number }>>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.RECENT, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get saved searches for a user
+   */
+  async getSavedSearches(userId: string): Promise<CatalogApiResponse<Array<{
+    id: string;
+    name: string;
+    query: any;
+    createdAt: Date;
+    lastUsed: Date;
+  }>>> {
+    const params = { userId };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      id: string;
+      name: string;
+      query: any;
+      createdAt: Date;
+      lastUsed: Date;
+    }>>>(
+      buildUrl(SEARCH_ENDPOINTS.SEARCH.SAVED, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Save a search query for later use
+   */
+  async saveSearch(
+    userId: string,
+    name: string,
+    query: any,
+    description?: string
+  ): Promise<CatalogApiResponse<{ id: string }>> {
+    const request = {
+      userId,
+      name,
+      query,
+      description
+    };
+
+    const response = await axios.post<CatalogApiResponse<{ id: string }>>(
+      SEARCH_ENDPOINTS.SEARCH.SAVED,
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // SEARCH PERSONALIZATION
+  // ============================================================================
+
+  /**
+   * Get user search profile and preferences
+   */
+  async getUserSearchProfile(userId: string): Promise<CatalogApiResponse<SearchPersonalization>> {
+    const response = await axios.get<CatalogApiResponse<SearchPersonalization>>(
+      SEARCH_ENDPOINTS.PERSONALIZATION.PROFILE(userId)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update user search preferences
+   */
+  async updateSearchPreferences(
+    userId: string,
+    preferences: any
+  ): Promise<CatalogApiResponse<void>> {
+    const response = await axios.put<CatalogApiResponse<void>>(
+      SEARCH_ENDPOINTS.PERSONALIZATION.PREFERENCES(userId),
+      preferences
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get personalized search recommendations for a user
+   */
+  async getPersonalizedRecommendations(
+    userId: string,
+    context?: any,
+    limit: number = 10
+  ): Promise<CatalogApiResponse<Array<{
+    type: string;
+    title: string;
+    query?: any;
+    assets?: IntelligentDataAsset[];
+    score: number;
+  }>>> {
+    const params = {
+      context: context ? JSON.stringify(context) : undefined,
+      limit
+    };
+
+    const response = await axios.get<CatalogApiResponse<Array<{
+      type: string;
+      title: string;
+      query?: any;
+      assets?: IntelligentDataAsset[];
+      score: number;
+    }>>>(
+      buildUrl(SEARCH_ENDPOINTS.PERSONALIZATION.RECOMMENDATIONS(userId), params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Provide feedback on search results to improve personalization
+   */
+  async provideFeedback(
+    userId: string,
+    searchId: string,
+    feedback: {
+      rating?: number;
+      relevantResults?: string[];
+      irrelevantResults?: string[];
+      comments?: string;
+    }
+  ): Promise<CatalogApiResponse<void>> {
+    const request = {
+      searchId,
+      feedback
+    };
+
+    const response = await axios.post<CatalogApiResponse<void>>(
+      SEARCH_ENDPOINTS.PERSONALIZATION.FEEDBACK(userId),
+      request
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // SEARCH CONFIGURATION & MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get current search engine configuration
+   */
+  async getSearchConfiguration(): Promise<CatalogApiResponse<any>> {
+    const response = await axios.get<CatalogApiResponse<any>>(
+      SEARCH_ENDPOINTS.CONFIGURATION.GET
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Update search engine configuration
+   */
+  async updateSearchConfiguration(config: any): Promise<CatalogApiResponse<void>> {
+    const response = await axios.put<CatalogApiResponse<void>>(
+      SEARCH_ENDPOINTS.CONFIGURATION.UPDATE,
+      config
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Validate search configuration
+   */
+  async validateSearchConfiguration(config: any): Promise<CatalogApiResponse<{
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+  }>> {
+    const response = await axios.post<CatalogApiResponse<{
+      valid: boolean;
+      errors: string[];
+      warnings: string[];
+    }>>(
+      SEARCH_ENDPOINTS.CONFIGURATION.VALIDATE,
+      config
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // SEARCH INDEX MANAGEMENT
+  // ============================================================================
+
+  /**
+   * Get search index status and health
+   */
+  async getIndexStatus(): Promise<CatalogApiResponse<{
+    status: string;
+    health: string;
+    totalDocuments: number;
+    indexSize: string;
+    lastUpdated: Date;
+  }>> {
+    const response = await axios.get<CatalogApiResponse<{
+      status: string;
+      health: string;
+      totalDocuments: number;
+      indexSize: string;
+      lastUpdated: Date;
+    }>>(
+      SEARCH_ENDPOINTS.INDEX.STATUS
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Trigger search index rebuild
+   */
+  async rebuildIndex(
+    incremental: boolean = false,
+    priority: 'LOW' | 'NORMAL' | 'HIGH' = 'NORMAL'
+  ): Promise<CatalogApiResponse<{ jobId: string; estimatedDuration: number }>> {
+    const request = {
+      incremental,
+      priority
+    };
+
+    const response = await axios.post<CatalogApiResponse<{ jobId: string; estimatedDuration: number }>>(
+      SEARCH_ENDPOINTS.INDEX.REBUILD,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Optimize search index for better performance
+   */
+  async optimizeIndex(): Promise<CatalogApiResponse<{ jobId: string }>> {
+    const response = await axios.post<CatalogApiResponse<{ jobId: string }>>(
+      SEARCH_ENDPOINTS.INDEX.OPTIMIZE
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get search index statistics
+   */
+  async getIndexStatistics(): Promise<CatalogApiResponse<any>> {
+    const response = await axios.get<CatalogApiResponse<any>>(
+      SEARCH_ENDPOINTS.INDEX.STATISTICS
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // SEARCH ANALYTICS
+  // ============================================================================
+
+  /**
+   * Get search analytics overview
+   */
+  async getSearchAnalyticsOverview(
+    request: SearchAnalyticsRequest
+  ): Promise<CatalogApiResponse<SearchAnalytics>> {
+    const response = await axios.post<CatalogApiResponse<SearchAnalytics>>(
+      SEARCH_ENDPOINTS.ANALYTICS.OVERVIEW,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get query analytics and performance metrics
+   */
+  async getQueryAnalytics(
+    startDate: Date,
+    endDate: Date,
+    topQueries: number = 100
+  ): Promise<CatalogApiResponse<any>> {
+    const params = {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      topQueries
+    };
+
+    const response = await axios.get<CatalogApiResponse<any>>(
+      buildUrl(SEARCH_ENDPOINTS.ANALYTICS.QUERIES, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get search performance analytics
+   */
+  async getPerformanceAnalytics(
+    startDate: Date,
+    endDate: Date
+  ): Promise<CatalogApiResponse<any>> {
+    const params = {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString()
+    };
+
+    const response = await axios.get<CatalogApiResponse<any>>(
+      buildUrl(SEARCH_ENDPOINTS.ANALYTICS.PERFORMANCE, params)
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get user behavior analytics
+   */
+  async getUserBehaviorAnalytics(
+    startDate: Date,
+    endDate: Date,
+    segment?: string
+  ): Promise<CatalogApiResponse<any>> {
+    const params = {
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      ...(segment && { segment })
+    };
+
+    const response = await axios.get<CatalogApiResponse<any>>(
+      buildUrl(SEARCH_ENDPOINTS.ANALYTICS.USER_BEHAVIOR, params)
+    );
+
+    return response.data;
+  }
+
+  // ============================================================================
+  // EXPORT & UTILITY OPERATIONS
+  // ============================================================================
+
+  /**
+   * Export search results to various formats
+   */
+  async exportSearchResults(
+    searchRequest: BasicSearchRequest,
+    format: 'CSV' | 'EXCEL' | 'JSON' | 'PDF',
+    includeMetadata: boolean = true
+  ): Promise<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>> {
+    const request = {
+      searchRequest,
+      format,
+      includeMetadata
+    };
+
+    const response = await axios.post<CatalogApiResponse<{ downloadUrl: string; expiresAt: Date }>>(
+      SEARCH_ENDPOINTS.SEARCH.EXPORT,
+      request
+    );
+
+    return response.data;
+  }
+
+  /**
+   * Get search recommendations for improving search quality
+   */
+  async getSearchOptimizationRecommendations(): Promise<CatalogApiResponse<Array<{
+    type: string;
+    title: string;
+    description: string;
+    impact: 'LOW' | 'MEDIUM' | 'HIGH';
+    effort: 'LOW' | 'MEDIUM' | 'HIGH';
+    implementation: string;
+  }>>> {
+    const response = await axios.get<CatalogApiResponse<Array<{
+      type: string;
+      title: string;
+      description: string;
+      impact: 'LOW' | 'MEDIUM' | 'HIGH';
+      effort: 'LOW' | 'MEDIUM' | 'HIGH';
+      implementation: string;
+    }>>>(
+      SEARCH_ENDPOINTS.ANALYTICS.RECOMMENDATIONS
+    );
+
+    return response.data;
+  }
+}
+
+// ============================================================================
+// EXPORT SERVICE INSTANCE
+// ============================================================================
+
+export const semanticSearchService = new SemanticSearchService();
+export default semanticSearchService;

--- a/v15_enhanced_1/components/Advanced-Catalog/types/analytics.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/analytics.types.ts
@@ -1,0 +1,835 @@
+// ============================================================================
+// ADVANCED CATALOG ANALYTICS TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: catalog_analytics_service.py, comprehensive_analytics_service.py
+// ============================================================================
+
+import { 
+  IntelligentDataAsset, 
+  AssetUsageMetrics,
+  TimePeriod,
+  BusinessGlossaryTerm 
+} from './catalog-core.types';
+
+// ============================================================================
+// CATALOG ANALYTICS TYPES (catalog_analytics_service.py)
+// ============================================================================
+
+export interface CatalogAnalyticsDashboard {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Dashboard Configuration
+  config: AnalyticsDashboardConfig;
+  
+  // Analytics Modules
+  usageAnalytics: UsageAnalyticsModule;
+  popularityAnalytics: PopularityAnalyticsModule;
+  businessAnalytics: BusinessAnalyticsModule;
+  technicalAnalytics: TechnicalAnalyticsModule;
+  
+  // Widgets
+  widgets: AnalyticsWidget[];
+  
+  // Time Range & Filters
+  timeRange: TimePeriod;
+  filters: AnalyticsFilter[];
+  
+  // Performance
+  performance: DashboardPerformance;
+  
+  // Personalization
+  userPreferences: AnalyticsUserPreferences;
+  
+  // Timestamps
+  createdAt: Date;
+  lastUpdated: Date;
+  lastViewed: Date;
+}
+
+export interface UsageAnalyticsModule {
+  id: string;
+  name: string;
+  
+  // Usage Metrics
+  totalUsage: UsageMetric;
+  userEngagement: UserEngagementMetric;
+  assetPopularity: AssetPopularityMetric;
+  
+  // Trends
+  usageTrends: UsageTrend[];
+  seasonalPatterns: SeasonalPattern[];
+  
+  // User Behavior
+  userBehavior: UserBehaviorAnalysis;
+  accessPatterns: AccessPatternAnalysis;
+  
+  // Recommendations
+  usageRecommendations: UsageRecommendation[];
+  
+  // Performance
+  performanceMetrics: UsagePerformanceMetrics;
+}
+
+export interface PopularityAnalyticsModule {
+  id: string;
+  name: string;
+  
+  // Popularity Metrics
+  popularAssets: PopularAssetMetric[];
+  trendingAssets: TrendingAssetMetric[];
+  emergingAssets: EmergingAssetMetric[];
+  
+  // Rankings
+  assetRankings: AssetRanking[];
+  categoryRankings: CategoryRanking[];
+  
+  // Popularity Factors
+  popularityFactors: PopularityFactor[];
+  
+  // Predictions
+  popularityPredictions: PopularityPrediction[];
+  
+  // Insights
+  popularityInsights: PopularityInsight[];
+}
+
+export interface BusinessAnalyticsModule {
+  id: string;
+  name: string;
+  
+  // Business Value Metrics
+  businessValue: BusinessValueMetric;
+  roi: ROIMetric;
+  costBenefit: CostBenefitAnalysis;
+  
+  // Business Impact
+  businessImpact: BusinessImpactAnalysis;
+  processOptimization: ProcessOptimizationMetric;
+  
+  // Governance Metrics
+  governanceMetrics: GovernanceMetric[];
+  complianceMetrics: ComplianceMetric[];
+  
+  // Strategic Insights
+  strategicInsights: StrategicInsight[];
+  
+  // Recommendations
+  businessRecommendations: BusinessRecommendation[];
+}
+
+export interface TechnicalAnalyticsModule {
+  id: string;
+  name: string;
+  
+  // Technical Performance
+  performance: TechnicalPerformanceMetric;
+  availability: AvailabilityMetric;
+  reliability: ReliabilityMetric;
+  
+  // Data Quality
+  qualityMetrics: TechnicalQualityMetric[];
+  
+  // System Health
+  systemHealth: SystemHealthMetric;
+  resourceUtilization: ResourceUtilizationMetric;
+  
+  // Integration Metrics
+  integrationMetrics: IntegrationMetric[];
+  
+  // Technical Insights
+  technicalInsights: TechnicalInsight[];
+}
+
+// ============================================================================
+// COMPREHENSIVE ANALYTICS TYPES (comprehensive_analytics_service.py)
+// ============================================================================
+
+export interface ComprehensiveAnalytics {
+  id: string;
+  name: string;
+  type: ComprehensiveAnalyticsType;
+  
+  // Cross-System Analytics
+  crossSystemMetrics: CrossSystemMetric[];
+  
+  // Enterprise Metrics
+  enterpriseMetrics: EnterpriseMetric[];
+  
+  // Predictive Analytics
+  predictiveAnalytics: PredictiveAnalyticsResults;
+  
+  // Advanced Insights
+  advancedInsights: AdvancedInsight[];
+  
+  // Benchmarking
+  benchmarking: BenchmarkingResults;
+  
+  // Custom Analytics
+  customAnalytics: CustomAnalyticsResults[];
+  
+  // Timestamps
+  generatedAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface CrossSystemMetric {
+  id: string;
+  name: string;
+  type: MetricType;
+  
+  // System Sources
+  sources: SystemSource[];
+  
+  // Metric Data
+  value: number;
+  previousValue?: number;
+  changePercentage: number;
+  
+  // Aggregation
+  aggregationType: AggregationType;
+  aggregationPeriod: TimePeriod;
+  
+  // Context
+  context: MetricContext;
+  
+  // Breakdown
+  breakdown: MetricBreakdown[];
+  
+  // Trends
+  trend: MetricTrend;
+  forecast: MetricForecast[];
+}
+
+export interface EnterpriseMetric {
+  id: string;
+  category: EnterpriseMetricCategory;
+  name: string;
+  description: string;
+  
+  // KPI Information
+  isKPI: boolean;
+  kpiTarget?: number;
+  kpiThreshold?: KPIThreshold;
+  
+  // Current Value
+  currentValue: number;
+  unit: string;
+  
+  // Historical Data
+  historicalData: MetricDataPoint[];
+  
+  // Performance
+  performance: MetricPerformance;
+  
+  // Business Context
+  businessContext: BusinessContext;
+  
+  // Alerts
+  alerts: MetricAlert[];
+}
+
+export interface PredictiveAnalyticsResults {
+  id: string;
+  modelType: PredictiveModelType;
+  
+  // Predictions
+  predictions: Prediction[];
+  
+  // Model Performance
+  modelPerformance: ModelPerformance;
+  
+  // Confidence Intervals
+  confidenceIntervals: ConfidenceInterval[];
+  
+  // Feature Importance
+  featureImportance: FeatureImportance[];
+  
+  // Validation Results
+  validationResults: ValidationResults;
+  
+  // Recommendations
+  predictiveRecommendations: PredictiveRecommendation[];
+}
+
+export interface AdvancedInsight {
+  id: string;
+  type: AdvancedInsightType;
+  category: InsightCategory;
+  title: string;
+  description: string;
+  
+  // Insight Data
+  data: InsightData;
+  evidence: InsightEvidence[];
+  
+  // Impact & Priority
+  impact: InsightImpact;
+  priority: InsightPriority;
+  confidence: number;
+  
+  // Action Items
+  actionItems: InsightActionItem[];
+  
+  // Business Value
+  businessValue: InsightBusinessValue;
+  
+  // Related Insights
+  relatedInsights: string[];
+  
+  // Validation
+  validated: boolean;
+  validationScore: number;
+  
+  // Timestamps
+  discoveredAt: Date;
+  lastValidated?: Date;
+}
+
+export interface BenchmarkingResults {
+  id: string;
+  benchmarkType: BenchmarkType;
+  
+  // Benchmark Data
+  benchmarks: Benchmark[];
+  
+  // Comparisons
+  industryComparison: IndustryComparison;
+  peerComparison: PeerComparison;
+  
+  // Performance Gaps
+  performanceGaps: PerformanceGap[];
+  
+  // Best Practices
+  bestPractices: BestPractice[];
+  
+  // Improvement Opportunities
+  improvementOpportunities: ImprovementOpportunity[];
+  
+  // Recommendations
+  benchmarkRecommendations: BenchmarkRecommendation[];
+}
+
+// ============================================================================
+// USAGE ANALYTICS TYPES
+// ============================================================================
+
+export interface UsageMetric {
+  totalViews: number;
+  uniqueUsers: number;
+  totalDownloads: number;
+  totalQueries: number;
+  averageSessionDuration: number;
+  bounceRate: number;
+  
+  // Time-based Metrics
+  dailyActiveUsers: number;
+  weeklyActiveUsers: number;
+  monthlyActiveUsers: number;
+  
+  // Engagement Metrics
+  averageViewsPerUser: number;
+  averageQueriesPerUser: number;
+  returnUserRate: number;
+  
+  // Growth Metrics
+  userGrowthRate: number;
+  usageGrowthRate: number;
+  
+  // Quality Metrics
+  successRate: number;
+  errorRate: number;
+}
+
+export interface UserEngagementMetric {
+  engagementScore: number;
+  
+  // Engagement Categories
+  highlyEngagedUsers: number;
+  moderatelyEngagedUsers: number;
+  lowEngagedUsers: number;
+  
+  // Engagement Activities
+  commentCount: number;
+  ratingCount: number;
+  sharingCount: number;
+  collaborationCount: number;
+  
+  // Engagement Trends
+  engagementTrend: EngagementTrend;
+  
+  // User Segments
+  engagementByUserSegment: EngagementSegment[];
+}
+
+export interface AssetPopularityMetric {
+  popularityScore: number;
+  popularityRank: number;
+  
+  // Popularity Factors
+  viewsWeight: number;
+  downloadsWeight: number;
+  ratingsWeight: number;
+  sharesWeight: number;
+  
+  // Viral Metrics
+  viralCoefficient: number;
+  sharingRate: number;
+  
+  // Temporal Popularity
+  currentPopularity: number;
+  peakPopularity: number;
+  averagePopularity: number;
+  
+  // Category Popularity
+  categoryRank: number;
+  categoryScore: number;
+}
+
+export interface UsageTrend {
+  trendType: TrendType;
+  period: TimePeriod;
+  dataPoints: TrendDataPoint[];
+  
+  // Trend Analysis
+  direction: TrendDirection;
+  strength: TrendStrength;
+  volatility: number;
+  
+  // Seasonal Analysis
+  seasonality: SeasonalityInfo;
+  cyclicalPatterns: CyclicalPattern[];
+  
+  // Forecasting
+  forecast: TrendForecast[];
+  
+  // Anomalies
+  anomalies: TrendAnomaly[];
+}
+
+export interface UserBehaviorAnalysis {
+  id: string;
+  userId?: string;
+  
+  // Behavior Patterns
+  behaviorPatterns: BehaviorPattern[];
+  
+  // Navigation Patterns
+  navigationPatterns: NavigationPattern[];
+  
+  // Search Behavior
+  searchBehavior: SearchBehaviorPattern;
+  
+  // Interaction Patterns
+  interactionPatterns: InteractionPattern[];
+  
+  // Preferences
+  preferenceProfile: UserPreferenceProfile;
+  
+  // Journey Analysis
+  userJourney: UserJourneyAnalysis;
+  
+  // Segmentation
+  userSegment: UserSegment;
+  
+  // Predictive Behavior
+  predictedBehavior: PredictedBehavior[];
+}
+
+// ============================================================================
+// BUSINESS ANALYTICS TYPES
+// ============================================================================
+
+export interface BusinessValueMetric {
+  totalBusinessValue: number;
+  
+  // Value Components
+  costSavings: number;
+  revenueGeneration: number;
+  riskReduction: number;
+  efficiencyGains: number;
+  
+  // Value Categories
+  operationalValue: number;
+  strategicValue: number;
+  complianceValue: number;
+  innovationValue: number;
+  
+  // Value Trends
+  valueGrowthRate: number;
+  valueVolatility: number;
+  
+  // ROI Metrics
+  returnOnInvestment: number;
+  netPresentValue: number;
+  paybackPeriod: number;
+}
+
+export interface ROIMetric {
+  totalROI: number;
+  
+  // ROI Components
+  implementationCost: number;
+  operationalCost: number;
+  benefits: number;
+  savings: number;
+  
+  // Time-based ROI
+  firstYearROI: number;
+  threeYearROI: number;
+  fiveYearROI: number;
+  
+  // ROI Categories
+  technologyROI: number;
+  processROI: number;
+  peopleROI: number;
+  
+  // Risk-adjusted ROI
+  riskAdjustedROI: number;
+  confidenceLevel: number;
+}
+
+export interface CostBenefitAnalysis {
+  id: string;
+  
+  // Costs
+  costs: CostComponent[];
+  totalCosts: number;
+  
+  // Benefits
+  benefits: BenefitComponent[];
+  totalBenefits: number;
+  
+  // Net Analysis
+  netBenefit: number;
+  benefitCostRatio: number;
+  
+  // Time Analysis
+  timeToBreakEven: number;
+  
+  // Sensitivity Analysis
+  sensitivityAnalysis: SensitivityResult[];
+  
+  // Risk Analysis
+  riskAnalysis: RiskAnalysisResult;
+}
+
+export interface ProcessOptimizationMetric {
+  id: string;
+  processName: string;
+  
+  // Efficiency Metrics
+  processEfficiency: number;
+  timeReduction: number;
+  resourceReduction: number;
+  errorReduction: number;
+  
+  // Quality Metrics
+  processQuality: number;
+  outputQuality: number;
+  
+  // Automation Metrics
+  automationLevel: number;
+  manualStepsReduced: number;
+  
+  // Compliance Metrics
+  complianceImprovement: number;
+  auditReadiness: number;
+}
+
+// ============================================================================
+// PREDICTIVE ANALYTICS TYPES
+// ============================================================================
+
+export interface Prediction {
+  id: string;
+  predictionType: PredictionType;
+  targetVariable: string;
+  
+  // Prediction Values
+  predictedValue: number;
+  confidenceInterval: ConfidenceInterval;
+  
+  // Time Horizon
+  predictionHorizon: TimePeriod;
+  predictionDate: Date;
+  
+  // Model Information
+  modelId: string;
+  modelVersion: string;
+  
+  // Input Features
+  inputFeatures: PredictionFeature[];
+  
+  // Explanation
+  explanation: PredictionExplanation;
+  
+  // Validation
+  validationScore: number;
+  accuracy: number;
+}
+
+export interface ModelPerformance {
+  modelId: string;
+  
+  // Accuracy Metrics
+  accuracy: number;
+  precision: number;
+  recall: number;
+  f1Score: number;
+  
+  // Error Metrics
+  meanAbsoluteError: number;
+  meanSquaredError: number;
+  rootMeanSquaredError: number;
+  
+  // Validation Metrics
+  crossValidationScore: number;
+  holdoutValidationScore: number;
+  
+  // Model Stability
+  stabilityScore: number;
+  driftScore: number;
+  
+  // Feature Performance
+  featureStability: FeatureStabilityMetric[];
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum ComprehensiveAnalyticsType {
+  ENTERPRISE_OVERVIEW = 'ENTERPRISE_OVERVIEW',
+  CROSS_SYSTEM = 'CROSS_SYSTEM',
+  PREDICTIVE = 'PREDICTIVE',
+  BENCHMARKING = 'BENCHMARKING',
+  CUSTOM = 'CUSTOM'
+}
+
+export enum MetricType {
+  USAGE = 'USAGE',
+  PERFORMANCE = 'PERFORMANCE',
+  QUALITY = 'QUALITY',
+  BUSINESS = 'BUSINESS',
+  TECHNICAL = 'TECHNICAL',
+  COMPLIANCE = 'COMPLIANCE'
+}
+
+export enum AggregationType {
+  SUM = 'SUM',
+  AVERAGE = 'AVERAGE',
+  COUNT = 'COUNT',
+  MIN = 'MIN',
+  MAX = 'MAX',
+  MEDIAN = 'MEDIAN',
+  PERCENTILE = 'PERCENTILE'
+}
+
+export enum EnterpriseMetricCategory {
+  OPERATIONAL = 'OPERATIONAL',
+  FINANCIAL = 'FINANCIAL',
+  STRATEGIC = 'STRATEGIC',
+  COMPLIANCE = 'COMPLIANCE',
+  INNOVATION = 'INNOVATION',
+  CUSTOMER = 'CUSTOMER'
+}
+
+export enum PredictiveModelType {
+  REGRESSION = 'REGRESSION',
+  CLASSIFICATION = 'CLASSIFICATION',
+  TIME_SERIES = 'TIME_SERIES',
+  CLUSTERING = 'CLUSTERING',
+  ANOMALY_DETECTION = 'ANOMALY_DETECTION',
+  RECOMMENDATION = 'RECOMMENDATION'
+}
+
+export enum AdvancedInsightType {
+  TREND_ANALYSIS = 'TREND_ANALYSIS',
+  PATTERN_DETECTION = 'PATTERN_DETECTION',
+  ANOMALY_DETECTION = 'ANOMALY_DETECTION',
+  CORRELATION_ANALYSIS = 'CORRELATION_ANALYSIS',
+  CAUSAL_ANALYSIS = 'CAUSAL_ANALYSIS',
+  OPTIMIZATION = 'OPTIMIZATION',
+  FORECASTING = 'FORECASTING'
+}
+
+export enum BenchmarkType {
+  INDUSTRY = 'INDUSTRY',
+  PEER = 'PEER',
+  INTERNAL = 'INTERNAL',
+  BEST_PRACTICE = 'BEST_PRACTICE',
+  HISTORICAL = 'HISTORICAL'
+}
+
+export enum TrendType {
+  USAGE = 'USAGE',
+  PERFORMANCE = 'PERFORMANCE',
+  QUALITY = 'QUALITY',
+  ENGAGEMENT = 'ENGAGEMENT',
+  BUSINESS_VALUE = 'BUSINESS_VALUE'
+}
+
+export enum TrendDirection {
+  INCREASING = 'INCREASING',
+  DECREASING = 'DECREASING',
+  STABLE = 'STABLE',
+  VOLATILE = 'VOLATILE',
+  CYCLICAL = 'CYCLICAL'
+}
+
+export enum TrendStrength {
+  WEAK = 'WEAK',
+  MODERATE = 'MODERATE',
+  STRONG = 'STRONG',
+  VERY_STRONG = 'VERY_STRONG'
+}
+
+export enum PredictionType {
+  USAGE_FORECAST = 'USAGE_FORECAST',
+  QUALITY_FORECAST = 'QUALITY_FORECAST',
+  DEMAND_FORECAST = 'DEMAND_FORECAST',
+  RISK_PREDICTION = 'RISK_PREDICTION',
+  PERFORMANCE_PREDICTION = 'PERFORMANCE_PREDICTION',
+  BEHAVIOR_PREDICTION = 'BEHAVIOR_PREDICTION'
+}
+
+export enum InsightCategory {
+  OPERATIONAL = 'OPERATIONAL',
+  STRATEGIC = 'STRATEGIC',
+  TACTICAL = 'TACTICAL',
+  DIAGNOSTIC = 'DIAGNOSTIC',
+  PRESCRIPTIVE = 'PRESCRIPTIVE',
+  PREDICTIVE = 'PREDICTIVE'
+}
+
+export enum InsightPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum InsightImpact {
+  MINIMAL = 'MINIMAL',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  TRANSFORMATIONAL = 'TRANSFORMATIONAL'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface AnalyticsWidget {
+  id: string;
+  type: AnalyticsWidgetType;
+  title: string;
+  configuration: WidgetConfiguration;
+  data: WidgetData;
+  position: WidgetPosition;
+  size: WidgetSize;
+}
+
+export interface AnalyticsFilter {
+  field: string;
+  operator: FilterOperator;
+  value: any;
+  enabled: boolean;
+}
+
+export interface TrendDataPoint {
+  timestamp: Date;
+  value: number;
+  metadata?: Record<string, any>;
+}
+
+export interface MetricDataPoint {
+  timestamp: Date;
+  value: number;
+  context?: Record<string, any>;
+}
+
+export interface ConfidenceInterval {
+  lower: number;
+  upper: number;
+  confidence: number;
+}
+
+export interface FeatureImportance {
+  feature: string;
+  importance: number;
+  description?: string;
+}
+
+export interface SystemSource {
+  systemId: string;
+  systemName: string;
+  weight: number;
+}
+
+export interface MetricBreakdown {
+  category: string;
+  value: number;
+  percentage: number;
+}
+
+export interface KPIThreshold {
+  warningThreshold: number;
+  criticalThreshold: number;
+  targetThreshold: number;
+}
+
+export interface BusinessContext {
+  department: string;
+  businessUnit: string;
+  strategic: boolean;
+  priority: number;
+}
+
+export interface MetricAlert {
+  id: string;
+  type: AlertType;
+  severity: AlertSeverity;
+  message: string;
+  triggeredAt: Date;
+}
+
+export enum AnalyticsWidgetType {
+  LINE_CHART = 'LINE_CHART',
+  BAR_CHART = 'BAR_CHART',
+  PIE_CHART = 'PIE_CHART',
+  METRIC_CARD = 'METRIC_CARD',
+  TABLE = 'TABLE',
+  HEATMAP = 'HEATMAP',
+  GAUGE = 'GAUGE',
+  PROGRESS_BAR = 'PROGRESS_BAR'
+}
+
+export enum FilterOperator {
+  EQUALS = 'EQUALS',
+  NOT_EQUALS = 'NOT_EQUALS',
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  CONTAINS = 'CONTAINS',
+  IN = 'IN',
+  BETWEEN = 'BETWEEN'
+}
+
+export enum AlertType {
+  THRESHOLD = 'THRESHOLD',
+  ANOMALY = 'ANOMALY',
+  TREND = 'TREND',
+  PERFORMANCE = 'PERFORMANCE'
+}
+
+export enum AlertSeverity {
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR',
+  CRITICAL = 'CRITICAL'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/catalog-core.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/catalog-core.types.ts
@@ -1,0 +1,959 @@
+// ============================================================================
+// ADVANCED CATALOG CORE TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: advanced_catalog_models.py, catalog_intelligence_models.py,
+//          catalog_quality_models.py, data_lineage_models.py, catalog_models.py
+// ============================================================================
+
+import { ReactNode } from 'react';
+
+// ============================================================================
+// CORE INTELLIGENT DATA ASSET TYPES (advanced_catalog_models.py)
+// ============================================================================
+
+export interface IntelligentDataAsset {
+  id: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  qualifiedName: string;
+  assetType: DataAssetType;
+  status: AssetStatus;
+  
+  // Schema Information
+  schema: DataAssetSchema;
+  columns: DataColumn[];
+  
+  // Quality & Classification
+  qualityScore: number;
+  qualityAssessment: DataQualityAssessment;
+  classifications: DataClassification[];
+  sensitivityLevel: SensitivityLevel;
+  
+  // Business Context
+  businessTerms: BusinessGlossaryTerm[];
+  owner: AssetOwner;
+  stewards: AssetSteward[];
+  
+  // Technical Metadata
+  technicalMetadata: TechnicalMetadata;
+  dataSource: DataSourceInfo;
+  
+  // Usage & Analytics
+  usageMetrics: AssetUsageMetrics;
+  popularityScore: number;
+  lastAccessed: Date;
+  accessFrequency: AccessFrequency;
+  
+  // AI Features
+  semanticEmbedding?: SemanticEmbedding;
+  recommendations: AssetRecommendation[];
+  insights: IntelligenceInsight[];
+  
+  // Lineage
+  upstreamAssets: LineageConnection[];
+  downstreamAssets: LineageConnection[];
+  lineageLevel: number;
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  discoveredAt: Date;
+  lastModified: Date;
+}
+
+export interface DataAssetSchema {
+  id: string;
+  name: string;
+  version: string;
+  format: SchemaFormat;
+  columns: DataColumn[];
+  constraints: SchemaConstraint[];
+  evolution: SchemaEvolution[];
+  metadata: Record<string, any>;
+}
+
+export interface DataColumn {
+  id: string;
+  name: string;
+  displayName?: string;
+  dataType: DataType;
+  nullable: boolean;
+  primaryKey: boolean;
+  foreignKey?: ForeignKeyInfo;
+  
+  // Quality Information
+  qualityRules: DataQualityRule[];
+  qualityScore: number;
+  nullPercentage: number;
+  uniqueness: number;
+  
+  // Statistical Profile
+  profile: ColumnProfile;
+  distribution: DataDistribution;
+  
+  // Classification
+  classifications: DataClassification[];
+  sensitivityLevel: SensitivityLevel;
+  piiType?: PIIType;
+  
+  // Business Context
+  businessTerms: BusinessGlossaryTerm[];
+  description?: string;
+  businessRules: string[];
+  
+  // Lineage
+  sourceColumns: ColumnLineage[];
+  derivedColumns: ColumnLineage[];
+  transformations: ColumnTransformation[];
+}
+
+// ============================================================================
+// ENTERPRISE DATA LINEAGE TYPES (data_lineage_models.py)
+// ============================================================================
+
+export interface EnterpriseDataLineage {
+  id: string;
+  sourceAsset: IntelligentDataAsset;
+  targetAsset: IntelligentDataAsset;
+  lineageType: LineageType;
+  direction: LineageDirection;
+  
+  // Column-Level Lineage
+  columnMappings: ColumnLineageMapping[];
+  transformations: DataTransformation[];
+  
+  // Lineage Graph
+  nodes: DataLineageNode[];
+  edges: DataLineageEdge[];
+  paths: LineagePath[];
+  
+  // Impact Analysis
+  impactAnalysis: LineageImpactAnalysis;
+  dependencies: LineageDependency[];
+  
+  // Visualization
+  visualizationConfig: LineageVisualizationConfig;
+  layout: LineageLayout;
+  
+  // Metrics
+  metrics: LineageMetrics;
+  confidence: number;
+  
+  // Timestamps
+  createdAt: Date;
+  lastUpdated: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface DataLineageNode {
+  id: string;
+  assetId: string;
+  nodeType: LineageNodeType;
+  position: NodePosition;
+  metadata: NodeMetadata;
+  properties: Record<string, any>;
+}
+
+export interface DataLineageEdge {
+  id: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  edgeType: LineageEdgeType;
+  transformationType: TransformationType;
+  properties: Record<string, any>;
+}
+
+export interface LineageImpactAnalysis {
+  id: string;
+  changeOrigin: string;
+  impactedAssets: ImpactedAsset[];
+  riskLevel: RiskLevel;
+  impactScope: ImpactScope;
+  recommendations: ImpactRecommendation[];
+  analysisMetrics: ImpactMetrics;
+}
+
+// ============================================================================
+// DATA QUALITY ASSESSMENT TYPES (catalog_quality_models.py)
+// ============================================================================
+
+export interface DataQualityAssessment {
+  id: string;
+  assetId: string;
+  assessmentType: QualityAssessmentType;
+  overallScore: number;
+  
+  // Quality Dimensions
+  completeness: QualityDimension;
+  accuracy: QualityDimension;
+  consistency: QualityDimension;
+  validity: QualityDimension;
+  uniqueness: QualityDimension;
+  timeliness: QualityDimension;
+  
+  // Quality Rules
+  rules: DataQualityRule[];
+  ruleResults: QualityRuleResult[];
+  
+  // Quality Score Card
+  scorecard: QualityScorecard;
+  trends: QualityTrend[];
+  
+  // Monitoring
+  monitoringConfig: QualityMonitoringConfig;
+  alerts: QualityMonitoringAlert[];
+  
+  // Reports
+  reports: QualityReport[];
+  
+  // AI Insights
+  aiInsights: QualityInsight[];
+  recommendations: QualityRecommendation[];
+  
+  // Timestamps
+  assessedAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface DataQualityRule {
+  id: string;
+  name: string;
+  description: string;
+  ruleType: QualityRuleType;
+  dimension: QualityDimension;
+  
+  // Rule Definition
+  expression: string;
+  threshold: QualityThreshold;
+  severity: QualitySeverity;
+  
+  // Configuration
+  enabled: boolean;
+  schedule: RuleSchedule;
+  scope: RuleScope;
+  
+  // Results
+  lastResult: QualityRuleResult;
+  successRate: number;
+  
+  // Metadata
+  owner: string;
+  tags: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface QualityScorecard {
+  id: string;
+  assetId: string;
+  period: TimePeriod;
+  
+  // Scores
+  overallScore: number;
+  dimensionScores: DimensionScore[];
+  
+  // Trends
+  scoreTrend: ScoreTrend;
+  improvement: QualityImprovement;
+  
+  // Benchmarks
+  industryBenchmark: number;
+  targetScore: number;
+  
+  // Insights
+  keyInsights: QualityInsight[];
+  actionItems: QualityActionItem[];
+}
+
+// ============================================================================
+// BUSINESS GLOSSARY TYPES (advanced_catalog_models.py)
+// ============================================================================
+
+export interface BusinessGlossaryTerm {
+  id: string;
+  name: string;
+  displayName: string;
+  definition: string;
+  longDescription?: string;
+  
+  // Hierarchy
+  parentTerm?: BusinessGlossaryTerm;
+  childTerms: BusinessGlossaryTerm[];
+  category: GlossaryCategory;
+  
+  // Relationships
+  synonyms: string[];
+  antonyms: string[];
+  relatedTerms: BusinessGlossaryTerm[];
+  
+  // Associations
+  associations: BusinessGlossaryAssociation[];
+  assets: IntelligentDataAsset[];
+  
+  // Governance
+  owner: TermOwner;
+  stewards: TermSteward[];
+  approvalStatus: ApprovalStatus;
+  
+  // Usage
+  usageCount: number;
+  lastUsed: Date;
+  
+  // Metadata
+  domain: BusinessDomain;
+  tags: string[];
+  attributes: TermAttribute[];
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  approvedAt?: Date;
+}
+
+export interface BusinessGlossaryAssociation {
+  id: string;
+  termId: string;
+  assetId: string;
+  associationType: AssociationType;
+  confidence: number;
+  
+  // Context
+  context: AssociationContext;
+  justification: string;
+  
+  // Validation
+  validated: boolean;
+  validatedBy?: string;
+  validatedAt?: Date;
+  
+  // AI Generated
+  aiGenerated: boolean;
+  aiConfidence: number;
+}
+
+// ============================================================================
+// SEMANTIC INTELLIGENCE TYPES (catalog_intelligence_models.py)
+// ============================================================================
+
+export interface SemanticEmbedding {
+  id: string;
+  assetId: string;
+  embeddingType: EmbeddingType;
+  vector: number[];
+  dimension: number;
+  
+  // Similarity
+  similarAssets: SimilarAsset[];
+  similarityThreshold: number;
+  
+  // Metadata
+  model: EmbeddingModel;
+  version: string;
+  createdAt: Date;
+  lastUpdated: Date;
+}
+
+export interface SemanticRelationship {
+  id: string;
+  sourceAssetId: string;
+  targetAssetId: string;
+  relationshipType: RelationshipType;
+  confidence: number;
+  
+  // Semantic Analysis
+  semanticSimilarity: number;
+  contextualRelevance: number;
+  
+  // Evidence
+  evidence: RelationshipEvidence[];
+  
+  // Validation
+  validated: boolean;
+  validatedBy?: string;
+  
+  // Timestamps
+  discoveredAt: Date;
+  lastValidated?: Date;
+}
+
+export interface RecommendationEngine {
+  id: string;
+  userId: string;
+  context: RecommendationContext;
+  
+  // Recommendations
+  assetRecommendations: AssetRecommendation[];
+  termRecommendations: TermRecommendation[];
+  actionRecommendations: ActionRecommendation[];
+  
+  // Configuration
+  preferences: UserPreferences;
+  filters: RecommendationFilter[];
+  
+  // Performance
+  metrics: RecommendationMetrics;
+  feedback: RecommendationFeedback[];
+}
+
+export interface AssetRecommendation {
+  id: string;
+  recommendedAsset: IntelligentDataAsset;
+  recommendationType: RecommendationType;
+  score: number;
+  confidence: number;
+  
+  // Context
+  reason: RecommendationReason;
+  context: RecommendationContext;
+  
+  // Personalization
+  userRelevance: number;
+  roleRelevance: number;
+  
+  // Actions
+  suggestedActions: SuggestedAction[];
+  
+  // Feedback
+  feedback?: RecommendationFeedback;
+  
+  // Timestamps
+  generatedAt: Date;
+  expiresAt?: Date;
+}
+
+// ============================================================================
+// USAGE PATTERNS & ANALYTICS TYPES
+// ============================================================================
+
+export interface AssetUsageMetrics {
+  id: string;
+  assetId: string;
+  period: TimePeriod;
+  
+  // Basic Metrics
+  totalViews: number;
+  uniqueUsers: number;
+  downloadCount: number;
+  queryCount: number;
+  
+  // Engagement
+  averageSessionDuration: number;
+  bounceRate: number;
+  returnUsers: number;
+  
+  // Access Patterns
+  accessPatterns: AccessPattern[];
+  peakUsageTimes: TimeSlot[];
+  userSegments: UserSegment[];
+  
+  // Geographic Distribution
+  geographicDistribution: GeographicUsage[];
+  
+  // Trends
+  usageTrend: UsageTrend;
+  seasonality: SeasonalityPattern[];
+  
+  // Collaboration
+  sharingCount: number;
+  collaborationMetrics: CollaborationMetrics;
+}
+
+export interface AssetUsagePattern {
+  id: string;
+  patternType: UsagePatternType;
+  pattern: PatternData;
+  frequency: PatternFrequency;
+  
+  // Analysis
+  insights: PatternInsight[];
+  anomalies: PatternAnomaly[];
+  
+  // Predictions
+  predictions: UsagePrediction[];
+  trends: PatternTrend[];
+}
+
+export interface IntelligenceInsight {
+  id: string;
+  insightType: InsightType;
+  category: InsightCategory;
+  title: string;
+  description: string;
+  
+  // Priority & Impact
+  priority: InsightPriority;
+  impact: InsightImpact;
+  confidence: number;
+  
+  // Data
+  data: InsightData;
+  metrics: InsightMetrics;
+  
+  // Actions
+  recommendations: InsightRecommendation[];
+  suggestedActions: SuggestedAction[];
+  
+  // Context
+  context: InsightContext;
+  relatedInsights: string[];
+  
+  // Timestamps
+  generatedAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface CollaborationInsight {
+  id: string;
+  collaborationType: CollaborationType;
+  participants: CollaborationParticipant[];
+  
+  // Metrics
+  collaborationLevel: number;
+  effectivenessScore: number;
+  
+  // Analysis
+  communicationPatterns: CommunicationPattern[];
+  workflowEfficiency: WorkflowEfficiency;
+  
+  // Recommendations
+  improvementSuggestions: ImprovementSuggestion[];
+  
+  // Timestamps
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+// ============================================================================
+// CATALOG ITEMS & MANAGEMENT TYPES (catalog_models.py)
+// ============================================================================
+
+export interface CatalogItem {
+  id: string;
+  name: string;
+  type: CatalogItemType;
+  status: CatalogItemStatus;
+  
+  // Metadata
+  metadata: CatalogMetadata;
+  properties: Record<string, any>;
+  
+  // Tags & Classification
+  tags: CatalogTag[];
+  categories: string[];
+  
+  // Ownership & Governance
+  owner: string;
+  stewards: string[];
+  
+  // Usage Tracking
+  usageLog: CatalogUsageLog[];
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  publishedAt?: Date;
+}
+
+export interface CatalogTag {
+  id: string;
+  name: string;
+  color: string;
+  description?: string;
+  category: TagCategory;
+  
+  // Usage
+  usageCount: number;
+  assets: string[];
+  
+  // Governance
+  owner: string;
+  approved: boolean;
+  
+  // Timestamps
+  createdAt: Date;
+  lastUsed: Date;
+}
+
+export interface CatalogItemTag {
+  id: string;
+  catalogItemId: string;
+  tagId: string;
+  confidence: number;
+  source: TagSource;
+  
+  // AI Generated
+  aiGenerated: boolean;
+  aiConfidence: number;
+  
+  // Validation
+  validated: boolean;
+  validatedBy?: string;
+  validatedAt?: Date;
+}
+
+export interface DataLineage {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  lineageType: string;
+  
+  // Transformation
+  transformation?: string;
+  confidence: number;
+  
+  // Metadata
+  metadata: LineageMetadata;
+  
+  // Timestamps
+  createdAt: Date;
+  lastValidated: Date;
+}
+
+export interface CatalogUsageLog {
+  id: string;
+  catalogItemId: string;
+  userId: string;
+  action: CatalogAction;
+  
+  // Context
+  sessionId: string;
+  ipAddress: string;
+  userAgent: string;
+  
+  // Details
+  details: UsageDetails;
+  
+  // Timestamps
+  timestamp: Date;
+  duration?: number;
+}
+
+export interface CatalogQualityRule {
+  id: string;
+  name: string;
+  description: string;
+  ruleType: string;
+  
+  // Configuration
+  config: QualityRuleConfig;
+  enabled: boolean;
+  
+  // Scope
+  scope: QualityRuleScope;
+  
+  // Results
+  lastResult?: QualityRuleResult;
+  successRate: number;
+  
+  // Timestamps
+  createdAt: Date;
+  lastRun?: Date;
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum DataAssetType {
+  TABLE = 'TABLE',
+  VIEW = 'VIEW',
+  COLUMN = 'COLUMN',
+  DATABASE = 'DATABASE',
+  SCHEMA = 'SCHEMA',
+  FILE = 'FILE',
+  API = 'API',
+  STREAM = 'STREAM',
+  DASHBOARD = 'DASHBOARD',
+  REPORT = 'REPORT',
+  MODEL = 'MODEL'
+}
+
+export enum AssetStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  DEPRECATED = 'DEPRECATED',
+  DRAFT = 'DRAFT',
+  ARCHIVED = 'ARCHIVED',
+  UNDER_REVIEW = 'UNDER_REVIEW'
+}
+
+export enum SchemaFormat {
+  PARQUET = 'PARQUET',
+  AVRO = 'AVRO',
+  JSON = 'JSON',
+  CSV = 'CSV',
+  ORC = 'ORC',
+  DELTA = 'DELTA',
+  ICEBERG = 'ICEBERG'
+}
+
+export enum DataType {
+  STRING = 'STRING',
+  INTEGER = 'INTEGER',
+  LONG = 'LONG',
+  FLOAT = 'FLOAT',
+  DOUBLE = 'DOUBLE',
+  BOOLEAN = 'BOOLEAN',
+  DATE = 'DATE',
+  DATETIME = 'DATETIME',
+  TIMESTAMP = 'TIMESTAMP',
+  DECIMAL = 'DECIMAL',
+  ARRAY = 'ARRAY',
+  STRUCT = 'STRUCT',
+  MAP = 'MAP',
+  BINARY = 'BINARY'
+}
+
+export enum SensitivityLevel {
+  PUBLIC = 'PUBLIC',
+  INTERNAL = 'INTERNAL',
+  CONFIDENTIAL = 'CONFIDENTIAL',
+  RESTRICTED = 'RESTRICTED',
+  TOP_SECRET = 'TOP_SECRET'
+}
+
+export enum PIIType {
+  NAME = 'NAME',
+  EMAIL = 'EMAIL',
+  PHONE = 'PHONE',
+  SSN = 'SSN',
+  CREDIT_CARD = 'CREDIT_CARD',
+  ADDRESS = 'ADDRESS',
+  NONE = 'NONE'
+}
+
+export enum LineageType {
+  DIRECT = 'DIRECT',
+  INDIRECT = 'INDIRECT',
+  DERIVED = 'DERIVED',
+  AGGREGATED = 'AGGREGATED',
+  TRANSFORMED = 'TRANSFORMED'
+}
+
+export enum LineageDirection {
+  UPSTREAM = 'UPSTREAM',
+  DOWNSTREAM = 'DOWNSTREAM',
+  BIDIRECTIONAL = 'BIDIRECTIONAL'
+}
+
+export enum TransformationType {
+  COPY = 'COPY',
+  FILTER = 'FILTER',
+  AGGREGATE = 'AGGREGATE',
+  JOIN = 'JOIN',
+  UNION = 'UNION',
+  TRANSFORM = 'TRANSFORM',
+  CALCULATE = 'CALCULATE',
+  CLEANSE = 'CLEANSE'
+}
+
+export enum QualityAssessmentType {
+  AUTOMATED = 'AUTOMATED',
+  MANUAL = 'MANUAL',
+  SCHEDULED = 'SCHEDULED',
+  ON_DEMAND = 'ON_DEMAND',
+  CONTINUOUS = 'CONTINUOUS'
+}
+
+export enum QualityRuleType {
+  COMPLETENESS = 'COMPLETENESS',
+  ACCURACY = 'ACCURACY',
+  CONSISTENCY = 'CONSISTENCY',
+  VALIDITY = 'VALIDITY',
+  UNIQUENESS = 'UNIQUENESS',
+  TIMELINESS = 'TIMELINESS',
+  CUSTOM = 'CUSTOM'
+}
+
+export enum QualitySeverity {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum RecommendationType {
+  SIMILAR_ASSETS = 'SIMILAR_ASSETS',
+  FREQUENTLY_USED_TOGETHER = 'FREQUENTLY_USED_TOGETHER',
+  USER_BASED = 'USER_BASED',
+  CONTENT_BASED = 'CONTENT_BASED',
+  HYBRID = 'HYBRID',
+  TRENDING = 'TRENDING',
+  QUALITY_IMPROVEMENT = 'QUALITY_IMPROVEMENT'
+}
+
+export enum InsightType {
+  USAGE_ANOMALY = 'USAGE_ANOMALY',
+  QUALITY_DECLINE = 'QUALITY_DECLINE',
+  PERFORMANCE_ISSUE = 'PERFORMANCE_ISSUE',
+  OPTIMIZATION_OPPORTUNITY = 'OPTIMIZATION_OPPORTUNITY',
+  COMPLIANCE_RISK = 'COMPLIANCE_RISK',
+  COST_OPTIMIZATION = 'COST_OPTIMIZATION',
+  SECURITY_CONCERN = 'SECURITY_CONCERN'
+}
+
+export enum CatalogItemType {
+  DATASET = 'DATASET',
+  TABLE = 'TABLE',
+  VIEW = 'VIEW',
+  DASHBOARD = 'DASHBOARD',
+  REPORT = 'REPORT',
+  MODEL = 'MODEL',
+  PIPELINE = 'PIPELINE',
+  WORKFLOW = 'WORKFLOW'
+}
+
+export enum CatalogAction {
+  VIEW = 'VIEW',
+  DOWNLOAD = 'DOWNLOAD',
+  QUERY = 'QUERY',
+  SHARE = 'SHARE',
+  FAVORITE = 'FAVORITE',
+  COMMENT = 'COMMENT',
+  RATE = 'RATE',
+  TAG = 'TAG',
+  EDIT = 'EDIT'
+}
+
+// ============================================================================
+// ADDITIONAL SUPPORTING TYPES
+// ============================================================================
+
+export interface TimePeriod {
+  start: Date;
+  end: Date;
+  granularity: 'HOUR' | 'DAY' | 'WEEK' | 'MONTH' | 'QUARTER' | 'YEAR';
+}
+
+export interface NodePosition {
+  x: number;
+  y: number;
+  z?: number;
+}
+
+export interface AccessFrequency {
+  daily: number;
+  weekly: number;
+  monthly: number;
+  trend: 'INCREASING' | 'DECREASING' | 'STABLE';
+}
+
+export interface TechnicalMetadata {
+  format: string;
+  compression?: string;
+  partitioning?: PartitionInfo[];
+  indexes?: IndexInfo[];
+  constraints?: ConstraintInfo[];
+  statistics?: StatisticsInfo;
+}
+
+export interface DataSourceInfo {
+  id: string;
+  name: string;
+  type: string;
+  connectionString?: string;
+  location: string;
+  lastScan: Date;
+}
+
+export interface AssetOwner {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  department: string;
+}
+
+export interface AssetSteward {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  responsibilities: string[];
+}
+
+// ============================================================================
+// API RESPONSE WRAPPERS
+// ============================================================================
+
+export interface CatalogApiResponse<T> {
+  data: T;
+  success: boolean;
+  message?: string;
+  errors?: ApiError[];
+  metadata?: ResponseMetadata;
+  pagination?: PaginationInfo;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+  field?: string;
+  details?: Record<string, any>;
+}
+
+export interface ResponseMetadata {
+  timestamp: Date;
+  version: string;
+  requestId: string;
+  executionTime: number;
+}
+
+export interface PaginationInfo {
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalItems: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+// ============================================================================
+// SEARCH & FILTER TYPES
+// ============================================================================
+
+export interface CatalogSearchRequest {
+  query: string;
+  filters: SearchFilter[];
+  sort: SortOption[];
+  pagination: PaginationRequest;
+  includeMetadata: boolean;
+  facets: string[];
+}
+
+export interface SearchFilter {
+  field: string;
+  operator: FilterOperator;
+  value: any;
+  values?: any[];
+}
+
+export interface SortOption {
+  field: string;
+  direction: 'ASC' | 'DESC';
+}
+
+export interface PaginationRequest {
+  page: number;
+  pageSize: number;
+}
+
+export enum FilterOperator {
+  EQUALS = 'EQUALS',
+  NOT_EQUALS = 'NOT_EQUALS',
+  CONTAINS = 'CONTAINS',
+  NOT_CONTAINS = 'NOT_CONTAINS',
+  STARTS_WITH = 'STARTS_WITH',
+  ENDS_WITH = 'ENDS_WITH',
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  NOT_IN = 'NOT_IN',
+  IS_NULL = 'IS_NULL',
+  IS_NOT_NULL = 'IS_NOT_NULL'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/collaboration.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/collaboration.types.ts
@@ -1,0 +1,844 @@
+// ============================================================================
+// ADVANCED CATALOG COLLABORATION TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: Collaboration features across multiple backend services
+// ============================================================================
+
+import { 
+  IntelligentDataAsset, 
+  BusinessGlossaryTerm,
+  TimePeriod 
+} from './catalog-core.types';
+
+// ============================================================================
+// COLLABORATION HUB TYPES
+// ============================================================================
+
+export interface CatalogCollaborationHub {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Hub Configuration
+  config: CollaborationHubConfig;
+  
+  // Teams & Members
+  teams: CollaborationTeam[];
+  members: CollaborationMember[];
+  
+  // Workspaces
+  workspaces: CollaborationWorkspace[];
+  
+  // Activities
+  activities: CollaborationActivity[];
+  
+  // Communication
+  communications: CommunicationChannel[];
+  
+  // Knowledge Sharing
+  knowledgeSharing: KnowledgeSharingConfig;
+  
+  // Analytics
+  analytics: CollaborationAnalytics;
+  
+  // Settings
+  settings: CollaborationSettings;
+}
+
+export interface CollaborationTeam {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Team Configuration
+  type: TeamType;
+  purpose: TeamPurpose;
+  
+  // Members
+  members: TeamMember[];
+  leaders: TeamLeader[];
+  
+  // Permissions
+  permissions: TeamPermissions;
+  
+  // Assets & Responsibilities
+  assignedAssets: string[];
+  responsibilities: TeamResponsibility[];
+  
+  // Goals & Metrics
+  goals: TeamGoal[];
+  metrics: TeamMetrics;
+  
+  // Communication
+  communicationChannels: CommunicationChannel[];
+  
+  // Status
+  status: TeamStatus;
+  
+  // Timestamps
+  createdAt: Date;
+  lastActivity: Date;
+}
+
+export interface CollaborationWorkspace {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Workspace Configuration
+  type: WorkspaceType;
+  visibility: WorkspaceVisibility;
+  
+  // Members & Access
+  members: WorkspaceMember[];
+  accessControl: WorkspaceAccessControl;
+  
+  // Content
+  assets: WorkspaceAsset[];
+  documents: WorkspaceDocument[];
+  discussions: WorkspaceDiscussion[];
+  
+  // Tools & Features
+  tools: WorkspaceTools;
+  features: WorkspaceFeature[];
+  
+  // Templates
+  templates: WorkspaceTemplate[];
+  
+  // Analytics
+  analytics: WorkspaceAnalytics;
+  
+  // Settings
+  settings: WorkspaceSettings;
+}
+
+// ============================================================================
+// DATA STEWARDSHIP TYPES
+// ============================================================================
+
+export interface DataStewardshipCenter {
+  id: string;
+  name: string;
+  
+  // Stewardship Configuration
+  config: StewardshipConfig;
+  
+  // Stewards & Roles
+  stewards: DataSteward[];
+  roles: StewardshipRole[];
+  
+  // Workflows
+  workflows: StewardshipWorkflow[];
+  
+  // Responsibilities
+  responsibilities: StewardshipResponsibility[];
+  
+  // Quality Management
+  qualityManagement: StewardshipQualityManagement;
+  
+  // Governance
+  governance: StewardshipGovernance;
+  
+  // Metrics & Reporting
+  metrics: StewardshipMetrics;
+  reporting: StewardshipReporting;
+}
+
+export interface DataSteward {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  
+  // Role & Responsibilities
+  role: StewardshipRole;
+  responsibilities: StewardResponsibility[];
+  
+  // Areas of Expertise
+  expertiseAreas: ExpertiseArea[];
+  domains: StewardshipDomain[];
+  
+  // Assigned Assets
+  assignedAssets: string[];
+  managedAssets: string[];
+  
+  // Performance
+  performance: StewardPerformance;
+  
+  // Activity
+  activities: StewardActivity[];
+  
+  // Certification
+  certifications: StewardCertification[];
+  
+  // Status
+  status: StewardStatus;
+  
+  // Timestamps
+  assignedAt: Date;
+  lastActive: Date;
+}
+
+export interface StewardshipWorkflow {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Workflow Configuration
+  type: WorkflowType;
+  steps: WorkflowStep[];
+  
+  // Triggers
+  triggers: WorkflowTrigger[];
+  
+  // Participants
+  participants: WorkflowParticipant[];
+  
+  // Approval Chain
+  approvalChain: ApprovalStep[];
+  
+  // Business Rules
+  businessRules: BusinessRule[];
+  
+  // SLAs
+  slas: WorkflowSLA[];
+  
+  // Notifications
+  notifications: WorkflowNotification[];
+  
+  // Status
+  status: WorkflowStatus;
+  
+  // Metrics
+  metrics: WorkflowMetrics;
+}
+
+// ============================================================================
+// ANNOTATION & DOCUMENTATION TYPES
+// ============================================================================
+
+export interface AnnotationManager {
+  id: string;
+  
+  // Annotation Configuration
+  config: AnnotationConfig;
+  
+  // Annotation Types
+  types: AnnotationType[];
+  
+  // Annotations
+  annotations: DataAnnotation[];
+  
+  // Templates
+  templates: AnnotationTemplate[];
+  
+  // Approval Process
+  approvalProcess: AnnotationApprovalProcess;
+  
+  // Analytics
+  analytics: AnnotationAnalytics;
+  
+  // Search & Discovery
+  searchConfig: AnnotationSearchConfig;
+}
+
+export interface DataAnnotation {
+  id: string;
+  
+  // Target Information
+  targetId: string;
+  targetType: AnnotationTargetType;
+  
+  // Annotation Content
+  content: AnnotationContent;
+  
+  // Author Information
+  authorId: string;
+  authorName: string;
+  
+  // Classification
+  type: AnnotationType;
+  category: AnnotationCategory;
+  tags: string[];
+  
+  // Visibility & Access
+  visibility: AnnotationVisibility;
+  permissions: AnnotationPermissions;
+  
+  // Lifecycle
+  status: AnnotationStatus;
+  approvalStatus: ApprovalStatus;
+  
+  // Relationships
+  parentAnnotation?: string;
+  childAnnotations: string[];
+  relatedAnnotations: string[];
+  
+  // Metrics
+  metrics: AnnotationMetrics;
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  approvedAt?: Date;
+}
+
+export interface ReviewWorkflowEngine {
+  id: string;
+  name: string;
+  
+  // Workflow Configuration
+  config: ReviewWorkflowConfig;
+  
+  // Review Types
+  reviewTypes: ReviewType[];
+  
+  // Active Reviews
+  activeReviews: AssetReview[];
+  
+  // Review Templates
+  templates: ReviewTemplate[];
+  
+  // Reviewers
+  reviewers: Reviewer[];
+  
+  // Escalation Rules
+  escalationRules: EscalationRule[];
+  
+  // Notifications
+  notifications: ReviewNotification[];
+  
+  // Analytics
+  analytics: ReviewAnalytics;
+}
+
+export interface AssetReview {
+  id: string;
+  
+  // Review Information
+  assetId: string;
+  reviewType: ReviewType;
+  
+  // Review Configuration
+  config: ReviewConfig;
+  
+  // Participants
+  requester: ReviewParticipant;
+  reviewers: ReviewParticipant[];
+  approvers: ReviewParticipant[];
+  
+  // Review Content
+  reviewItems: ReviewItem[];
+  criteria: ReviewCriteria[];
+  
+  // Status & Progress
+  status: ReviewStatus;
+  progress: ReviewProgress;
+  
+  // Results
+  results: ReviewResult[];
+  decision: ReviewDecision;
+  
+  // Comments & Feedback
+  comments: ReviewComment[];
+  feedback: ReviewFeedback[];
+  
+  // Timeline
+  timeline: ReviewTimeline;
+  
+  // Metrics
+  metrics: ReviewMetrics;
+}
+
+// ============================================================================
+// COMMUNITY & CROWDSOURCING TYPES
+// ============================================================================
+
+export interface CrowdsourcingPlatform {
+  id: string;
+  name: string;
+  
+  // Platform Configuration
+  config: CrowdsourcingConfig;
+  
+  // Campaigns
+  campaigns: CrowdsourcingCampaign[];
+  
+  // Contributors
+  contributors: CommunityContributor[];
+  
+  // Contributions
+  contributions: CommunityContribution[];
+  
+  // Incentives & Rewards
+  incentives: IncentiveProgram[];
+  rewards: RewardSystem;
+  
+  // Quality Control
+  qualityControl: CrowdsourcingQualityControl;
+  
+  // Analytics
+  analytics: CrowdsourcingAnalytics;
+  
+  // Governance
+  governance: CrowdsourcingGovernance;
+}
+
+export interface CommunityContributor {
+  id: string;
+  userId: string;
+  
+  // Profile Information
+  profile: ContributorProfile;
+  
+  // Reputation
+  reputation: ContributorReputation;
+  
+  // Expertise
+  expertise: ContributorExpertise[];
+  
+  // Contributions
+  contributions: CommunityContribution[];
+  contributionStats: ContributionStats;
+  
+  // Rewards & Recognition
+  rewards: ContributorReward[];
+  badges: ContributorBadge[];
+  
+  // Activity
+  activity: ContributorActivity;
+  
+  // Status
+  status: ContributorStatus;
+}
+
+export interface ExpertNetworking {
+  id: string;
+  name: string;
+  
+  // Network Configuration
+  config: ExpertNetworkConfig;
+  
+  // Experts
+  experts: DomainExpert[];
+  
+  // Expertise Domains
+  domains: ExpertiseDomain[];
+  
+  // Consultation Requests
+  consultationRequests: ConsultationRequest[];
+  
+  // Knowledge Exchange
+  knowledgeExchange: KnowledgeExchangeSession[];
+  
+  // Matching Algorithm
+  matchingAlgorithm: ExpertMatchingAlgorithm;
+  
+  // Analytics
+  analytics: ExpertNetworkAnalytics;
+  
+  // Quality Assurance
+  qualityAssurance: ExpertQualityAssurance;
+}
+
+export interface DomainExpert {
+  id: string;
+  userId: string;
+  
+  // Expert Profile
+  profile: ExpertProfile;
+  
+  // Expertise
+  expertiseDomains: ExpertiseDomain[];
+  expertiseLevel: ExpertiseLevel;
+  
+  // Credentials
+  credentials: ExpertCredential[];
+  certifications: ExpertCertification[];
+  
+  // Availability
+  availability: ExpertAvailability;
+  
+  // Performance
+  performance: ExpertPerformance;
+  
+  // Consultation History
+  consultationHistory: ConsultationHistory[];
+  
+  // Reputation
+  reputation: ExpertReputation;
+  
+  // Status
+  status: ExpertStatus;
+}
+
+// ============================================================================
+// KNOWLEDGE SHARING TYPES
+// ============================================================================
+
+export interface KnowledgeBase {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Knowledge Base Configuration
+  config: KnowledgeBaseConfig;
+  
+  // Content Organization
+  categories: KnowledgeCategory[];
+  topics: KnowledgeTopic[];
+  
+  // Knowledge Items
+  articles: KnowledgeArticle[];
+  tutorials: KnowledgeTutorial[];
+  faqs: KnowledgeFAQ[];
+  
+  // Content Management
+  contentManagement: KnowledgeContentManagement;
+  
+  // Search & Discovery
+  searchConfig: KnowledgeSearchConfig;
+  
+  // Collaboration
+  collaboration: KnowledgeCollaboration;
+  
+  // Analytics
+  analytics: KnowledgeAnalytics;
+  
+  // Quality Control
+  qualityControl: KnowledgeQualityControl;
+}
+
+export interface KnowledgeArticle {
+  id: string;
+  title: string;
+  content: string;
+  
+  // Metadata
+  metadata: ArticleMetadata;
+  
+  // Organization
+  category: KnowledgeCategory;
+  topics: KnowledgeTopic[];
+  tags: string[];
+  
+  // Authors & Contributors
+  authors: ArticleAuthor[];
+  contributors: ArticleContributor[];
+  
+  // Related Content
+  relatedAssets: string[];
+  relatedArticles: string[];
+  
+  // Lifecycle
+  status: ArticleStatus;
+  version: string;
+  history: ArticleHistory[];
+  
+  // Quality & Approval
+  qualityScore: number;
+  approvalStatus: ApprovalStatus;
+  
+  // Usage & Feedback
+  usage: ArticleUsage;
+  feedback: ArticleFeedback[];
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  publishedAt?: Date;
+}
+
+export interface CommunityForum {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Forum Configuration
+  config: ForumConfig;
+  
+  // Forum Structure
+  categories: ForumCategory[];
+  topics: ForumTopic[];
+  
+  // Discussions
+  discussions: ForumDiscussion[];
+  
+  // Members
+  members: ForumMember[];
+  moderators: ForumModerator[];
+  
+  // Moderation
+  moderation: ForumModeration;
+  
+  // Analytics
+  analytics: ForumAnalytics;
+  
+  // Gamification
+  gamification: ForumGamification;
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum TeamType {
+  DATA_STEWARDSHIP = 'DATA_STEWARDSHIP',
+  QUALITY_ASSURANCE = 'QUALITY_ASSURANCE',
+  COMPLIANCE = 'COMPLIANCE',
+  ANALYTICS = 'ANALYTICS',
+  ENGINEERING = 'ENGINEERING',
+  BUSINESS = 'BUSINESS',
+  CROSS_FUNCTIONAL = 'CROSS_FUNCTIONAL'
+}
+
+export enum TeamPurpose {
+  ASSET_MANAGEMENT = 'ASSET_MANAGEMENT',
+  QUALITY_CONTROL = 'QUALITY_CONTROL',
+  COMPLIANCE_MONITORING = 'COMPLIANCE_MONITORING',
+  INNOVATION = 'INNOVATION',
+  OPERATIONAL_SUPPORT = 'OPERATIONAL_SUPPORT',
+  STRATEGIC_PLANNING = 'STRATEGIC_PLANNING'
+}
+
+export enum WorkspaceType {
+  PROJECT = 'PROJECT',
+  DOMAIN = 'DOMAIN',
+  TEMPORARY = 'TEMPORARY',
+  PERMANENT = 'PERMANENT',
+  INITIATIVE = 'INITIATIVE'
+}
+
+export enum WorkspaceVisibility {
+  PUBLIC = 'PUBLIC',
+  PRIVATE = 'PRIVATE',
+  RESTRICTED = 'RESTRICTED',
+  TEAM_ONLY = 'TEAM_ONLY'
+}
+
+export enum AnnotationTargetType {
+  ASSET = 'ASSET',
+  COLUMN = 'COLUMN',
+  SCHEMA = 'SCHEMA',
+  BUSINESS_TERM = 'BUSINESS_TERM',
+  RELATIONSHIP = 'RELATIONSHIP',
+  TRANSFORMATION = 'TRANSFORMATION'
+}
+
+export enum AnnotationType {
+  COMMENT = 'COMMENT',
+  DOCUMENTATION = 'DOCUMENTATION',
+  BUSINESS_CONTEXT = 'BUSINESS_CONTEXT',
+  TECHNICAL_NOTE = 'TECHNICAL_NOTE',
+  QUALITY_NOTE = 'QUALITY_NOTE',
+  COMPLIANCE_NOTE = 'COMPLIANCE_NOTE',
+  WARNING = 'WARNING',
+  RECOMMENDATION = 'RECOMMENDATION'
+}
+
+export enum AnnotationStatus {
+  DRAFT = 'DRAFT',
+  PENDING_REVIEW = 'PENDING_REVIEW',
+  APPROVED = 'APPROVED',
+  PUBLISHED = 'PUBLISHED',
+  REJECTED = 'REJECTED',
+  ARCHIVED = 'ARCHIVED'
+}
+
+export enum ReviewType {
+  QUALITY_REVIEW = 'QUALITY_REVIEW',
+  COMPLIANCE_REVIEW = 'COMPLIANCE_REVIEW',
+  BUSINESS_REVIEW = 'BUSINESS_REVIEW',
+  TECHNICAL_REVIEW = 'TECHNICAL_REVIEW',
+  METADATA_REVIEW = 'METADATA_REVIEW',
+  CLASSIFICATION_REVIEW = 'CLASSIFICATION_REVIEW'
+}
+
+export enum ReviewStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  UNDER_REVIEW = 'UNDER_REVIEW',
+  PENDING_APPROVAL = 'PENDING_APPROVAL',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  CANCELLED = 'CANCELLED'
+}
+
+export enum ExpertiseLevel {
+  NOVICE = 'NOVICE',
+  INTERMEDIATE = 'INTERMEDIATE',
+  ADVANCED = 'ADVANCED',
+  EXPERT = 'EXPERT',
+  THOUGHT_LEADER = 'THOUGHT_LEADER'
+}
+
+export enum ContributorStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  BANNED = 'BANNED',
+  PROBATION = 'PROBATION'
+}
+
+export enum ArticleStatus {
+  DRAFT = 'DRAFT',
+  REVIEW = 'REVIEW',
+  PUBLISHED = 'PUBLISHED',
+  ARCHIVED = 'ARCHIVED',
+  DEPRECATED = 'DEPRECATED'
+}
+
+export enum ApprovalStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  NEEDS_REVISION = 'NEEDS_REVISION'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface CollaborationMember {
+  userId: string;
+  name: string;
+  email: string;
+  role: CollaborationRole;
+  permissions: CollaborationPermissions;
+  joinedAt: Date;
+  lastActive: Date;
+}
+
+export interface CollaborationActivity {
+  id: string;
+  type: ActivityType;
+  userId: string;
+  description: string;
+  metadata: Record<string, any>;
+  timestamp: Date;
+}
+
+export interface CommunicationChannel {
+  id: string;
+  name: string;
+  type: ChannelType;
+  participants: string[];
+  messages: ChannelMessage[];
+  settings: ChannelSettings;
+}
+
+export interface TeamMember {
+  userId: string;
+  role: TeamMemberRole;
+  permissions: TeamMemberPermissions;
+  responsibilities: string[];
+  expertise: string[];
+  joinedAt: Date;
+}
+
+export interface StewardResponsibility {
+  id: string;
+  name: string;
+  description: string;
+  scope: ResponsibilityScope;
+  priority: ResponsibilityPriority;
+  metrics: ResponsibilityMetrics;
+}
+
+export interface ReviewItem {
+  id: string;
+  type: ReviewItemType;
+  content: any;
+  criteria: ReviewCriteria;
+  result: ReviewItemResult;
+  comments: string[];
+}
+
+export interface CommunityContribution {
+  id: string;
+  contributorId: string;
+  type: ContributionType;
+  content: any;
+  quality: ContributionQuality;
+  impact: ContributionImpact;
+  recognition: ContributionRecognition;
+  timestamp: Date;
+}
+
+export interface ConsultationRequest {
+  id: string;
+  requesterId: string;
+  expertId?: string;
+  topic: string;
+  description: string;
+  urgency: ConsultationUrgency;
+  status: ConsultationStatus;
+  outcome: ConsultationOutcome;
+  feedback: ConsultationFeedback;
+}
+
+export interface AnnotationContent {
+  text: string;
+  format: ContentFormat;
+  attachments: Attachment[];
+  links: ContentLink[];
+  mentions: ContentMention[];
+}
+
+export enum CollaborationRole {
+  VIEWER = 'VIEWER',
+  CONTRIBUTOR = 'CONTRIBUTOR',
+  MODERATOR = 'MODERATOR',
+  ADMINISTRATOR = 'ADMINISTRATOR',
+  OWNER = 'OWNER'
+}
+
+export enum ActivityType {
+  ASSET_VIEW = 'ASSET_VIEW',
+  ASSET_EDIT = 'ASSET_EDIT',
+  COMMENT_ADD = 'COMMENT_ADD',
+  ANNOTATION_CREATE = 'ANNOTATION_CREATE',
+  REVIEW_SUBMIT = 'REVIEW_SUBMIT',
+  COLLABORATION_JOIN = 'COLLABORATION_JOIN',
+  KNOWLEDGE_SHARE = 'KNOWLEDGE_SHARE'
+}
+
+export enum ChannelType {
+  DISCUSSION = 'DISCUSSION',
+  ANNOUNCEMENT = 'ANNOUNCEMENT',
+  DIRECT_MESSAGE = 'DIRECT_MESSAGE',
+  GROUP_CHAT = 'GROUP_CHAT',
+  NOTIFICATION = 'NOTIFICATION'
+}
+
+export enum ContributionType {
+  ANNOTATION = 'ANNOTATION',
+  DOCUMENTATION = 'DOCUMENTATION',
+  QUALITY_IMPROVEMENT = 'QUALITY_IMPROVEMENT',
+  CLASSIFICATION = 'CLASSIFICATION',
+  RELATIONSHIP_MAPPING = 'RELATIONSHIP_MAPPING',
+  REVIEW = 'REVIEW'
+}
+
+export enum ConsultationUrgency {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum ConsultationStatus {
+  REQUESTED = 'REQUESTED',
+  MATCHED = 'MATCHED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED'
+}
+
+export enum ContentFormat {
+  PLAIN_TEXT = 'PLAIN_TEXT',
+  MARKDOWN = 'MARKDOWN',
+  HTML = 'HTML',
+  RICH_TEXT = 'RICH_TEXT'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/discovery.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/discovery.types.ts
@@ -1,0 +1,707 @@
+// ============================================================================
+// ADVANCED CATALOG DISCOVERY TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: intelligent_discovery_service.py, data_profiling_service.py
+// ============================================================================
+
+import { 
+  IntelligentDataAsset, 
+  DataAssetType, 
+  SensitivityLevel,
+  DataColumn,
+  TechnicalMetadata,
+  TimePeriod 
+} from './catalog-core.types';
+
+// ============================================================================
+// INTELLIGENT DISCOVERY TYPES (intelligent_discovery_service.py)
+// ============================================================================
+
+export interface DiscoveryConfiguration {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Discovery Scope
+  sources: DiscoverySource[];
+  includeTypes: DataAssetType[];
+  excludePatterns: string[];
+  
+  // AI Configuration
+  aiEnabled: boolean;
+  classificationEnabled: boolean;
+  profilingEnabled: boolean;
+  lineageDiscoveryEnabled: boolean;
+  
+  // Scheduling
+  schedule: DiscoverySchedule;
+  priority: DiscoveryPriority;
+  
+  // Quality & Performance
+  qualityThreshold: number;
+  timeout: number;
+  parallelism: number;
+  
+  // Notifications
+  notificationConfig: DiscoveryNotificationConfig;
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  lastRun?: Date;
+}
+
+export interface DiscoverySource {
+  id: string;
+  name: string;
+  type: DiscoverySourceType;
+  connectionString: string;
+  
+  // Authentication
+  credentials: DiscoveryCredentials;
+  
+  // Configuration
+  config: SourceConfig;
+  filters: SourceFilter[];
+  
+  // Status
+  status: SourceStatus;
+  lastScan: Date;
+  
+  // Performance
+  scanDuration: number;
+  assetsDiscovered: number;
+  errorCount: number;
+}
+
+export interface DiscoveryJob {
+  id: string;
+  configurationId: string;
+  status: DiscoveryJobStatus;
+  
+  // Execution Details
+  startTime: Date;
+  endTime?: Date;
+  duration?: number;
+  
+  // Progress
+  progress: DiscoveryProgress;
+  currentPhase: DiscoveryPhase;
+  
+  // Results
+  results: DiscoveryJobResult;
+  
+  // Performance
+  performance: DiscoveryPerformance;
+  
+  // Errors & Warnings
+  errors: DiscoveryError[];
+  warnings: DiscoveryWarning[];
+  
+  // Logs
+  logs: DiscoveryLog[];
+}
+
+export interface DiscoveryJobResult {
+  totalAssetsFound: number;
+  newAssetsDiscovered: number;
+  existingAssetsUpdated: number;
+  assetsClassified: number;
+  assetsProfiled: number;
+  
+  // Asset Breakdown
+  assetsByType: AssetTypeCount[];
+  assetsBySensitivity: SensitivityCount[];
+  
+  // Quality Metrics
+  qualityIssuesFound: number;
+  averageQualityScore: number;
+  
+  // Lineage Discovery
+  lineageRelationsFound: number;
+  newLineageConnections: number;
+  
+  // Schema Analysis
+  schemasAnalyzed: number;
+  schemaChangesDetected: number;
+  
+  // Assets Details
+  discoveredAssets: DiscoveredAsset[];
+  updatedAssets: UpdatedAsset[];
+}
+
+export interface DiscoveredAsset {
+  asset: IntelligentDataAsset;
+  discoveryMethod: DiscoveryMethod;
+  confidence: number;
+  
+  // Classification Results
+  autoClassifications: AutoClassificationResult[];
+  sensitivityClassification: SensitivityClassificationResult;
+  
+  // Profiling Results
+  profilingResult?: DataProfilingResult;
+  
+  // Schema Analysis
+  schemaAnalysis: SchemaAnalysisResult;
+  
+  // Quality Assessment
+  qualityAssessment: DiscoveryQualityAssessment;
+  
+  // Lineage Discovery
+  discoveredLineage: DiscoveredLineage[];
+  
+  // AI Insights
+  aiInsights: DiscoveryAIInsight[];
+  
+  // Metadata Enrichment
+  enrichedMetadata: EnrichedMetadata;
+}
+
+export interface AutoClassificationResult {
+  classificationType: string;
+  confidence: number;
+  method: ClassificationMethod;
+  
+  // Rule-Based Classification
+  ruleMatches?: RuleMatch[];
+  
+  // ML-Based Classification
+  mlPrediction?: MLPrediction;
+  
+  // Pattern-Based Classification
+  patternMatches?: PatternMatch[];
+  
+  // Evidence
+  evidence: ClassificationEvidence[];
+  
+  // Validation
+  validated: boolean;
+  validationMethod?: ValidationMethod;
+}
+
+export interface SensitivityClassificationResult {
+  sensitivityLevel: SensitivityLevel;
+  confidence: number;
+  reasons: SensitivityReason[];
+  
+  // PII Detection
+  piiElements: PIIElement[];
+  
+  // Regulatory Classification
+  regulatoryClassifications: RegulatoryClassification[];
+  
+  // Risk Assessment
+  riskLevel: RiskLevel;
+  riskFactors: RiskFactor[];
+  
+  // Recommendations
+  recommendations: SensitivityRecommendation[];
+}
+
+// ============================================================================
+// DATA PROFILING TYPES (data_profiling_service.py)
+// ============================================================================
+
+export interface DataProfilingResult {
+  id: string;
+  assetId: string;
+  profiledAt: Date;
+  
+  // Overall Statistics
+  rowCount: number;
+  columnCount: number;
+  sizeInBytes: number;
+  
+  // Column Profiles
+  columnProfiles: ColumnProfile[];
+  
+  // Quality Metrics
+  qualityMetrics: ProfilingQualityMetrics;
+  
+  // Data Patterns
+  dataPatterns: DataPattern[];
+  
+  // Anomalies
+  anomalies: DataAnomaly[];
+  
+  // Relationships
+  relationships: DataRelationship[];
+  
+  // Statistical Summary
+  statisticalSummary: StatisticalSummary;
+  
+  // Performance
+  profilingDuration: number;
+  samplingStrategy: SamplingStrategy;
+}
+
+export interface ColumnProfile {
+  columnName: string;
+  dataType: string;
+  
+  // Basic Statistics
+  nullCount: number;
+  nullPercentage: number;
+  distinctCount: number;
+  uniqueness: number;
+  
+  // String Statistics
+  minLength?: number;
+  maxLength?: number;
+  averageLength?: number;
+  
+  // Numeric Statistics
+  minValue?: number;
+  maxValue?: number;
+  averageValue?: number;
+  medianValue?: number;
+  standardDeviation?: number;
+  
+  // Distribution
+  distribution: ValueDistribution;
+  histogram: HistogramBin[];
+  
+  // Patterns
+  patterns: ColumnPattern[];
+  
+  // Quality Issues
+  qualityIssues: ColumnQualityIssue[];
+  
+  // Sample Values
+  sampleValues: any[];
+  topValues: ValueFrequency[];
+}
+
+export interface ProfilingQualityMetrics {
+  overallScore: number;
+  
+  // Completeness
+  completenessScore: number;
+  missingDataPercentage: number;
+  
+  // Validity
+  validityScore: number;
+  invalidRecords: number;
+  
+  // Consistency
+  consistencyScore: number;
+  inconsistentFormats: number;
+  
+  // Uniqueness
+  uniquenessScore: number;
+  duplicateRecords: number;
+  
+  // Accuracy
+  accuracyScore: number;
+  suspiciousValues: number;
+}
+
+export interface SchemaAnalysisResult {
+  id: string;
+  assetId: string;
+  analyzedAt: Date;
+  
+  // Schema Structure
+  schemaStructure: SchemaStructure;
+  
+  // Evolution Analysis
+  schemaEvolution: SchemaEvolution[];
+  compatibilityStatus: CompatibilityStatus;
+  
+  // Relationships
+  foreignKeyRelationships: ForeignKeyRelationship[];
+  
+  // Constraints
+  constraints: SchemaConstraint[];
+  constraintViolations: ConstraintViolation[];
+  
+  // Recommendations
+  schemaRecommendations: SchemaRecommendation[];
+  
+  // Quality Assessment
+  schemaQuality: SchemaQuality;
+}
+
+export interface DiscoveryQualityAssessment {
+  overallScore: number;
+  
+  // Discovery Quality
+  discoveryAccuracy: number;
+  discoveryCompleteness: number;
+  
+  // Classification Quality
+  classificationAccuracy: number;
+  classificationCoverage: number;
+  
+  // Profiling Quality
+  profilingCompleteness: number;
+  profilingAccuracy: number;
+  
+  // Lineage Quality
+  lineageAccuracy: number;
+  lineageCoverage: number;
+  
+  // Issues
+  qualityIssues: DiscoveryQualityIssue[];
+  
+  // Recommendations
+  improvementRecommendations: QualityImprovement[];
+}
+
+export interface DiscoveredLineage {
+  sourceAssetId: string;
+  targetAssetId: string;
+  lineageType: string;
+  confidence: number;
+  
+  // Discovery Method
+  discoveryMethod: LineageDiscoveryMethod;
+  
+  // Evidence
+  evidence: LineageEvidence[];
+  
+  // Transformation Details
+  transformation?: LineageTransformation;
+  
+  // Validation
+  validated: boolean;
+  validationScore: number;
+}
+
+export interface DiscoveryAIInsight {
+  id: string;
+  type: AIInsightType;
+  title: string;
+  description: string;
+  confidence: number;
+  
+  // Impact & Priority
+  impact: InsightImpact;
+  priority: InsightPriority;
+  
+  // Data
+  data: AIInsightData;
+  
+  // Recommendations
+  recommendations: AIRecommendation[];
+  
+  // Actions
+  suggestedActions: DiscoveryAction[];
+  
+  // Context
+  context: DiscoveryContext;
+}
+
+export interface EnrichedMetadata {
+  businessTerms: EnrichedBusinessTerm[];
+  technicalTags: EnrichedTag[];
+  descriptions: EnrichedDescription[];
+  
+  // External Enrichment
+  externalSources: ExternalMetadataSource[];
+  
+  // AI Enrichment
+  aiGeneratedMetadata: AIGeneratedMetadata[];
+  
+  // User Contributions
+  userContributions: UserMetadataContribution[];
+  
+  // Quality Score
+  enrichmentQuality: number;
+  completenessScore: number;
+}
+
+// ============================================================================
+// INCREMENTAL DISCOVERY TYPES
+// ============================================================================
+
+export interface IncrementalDiscoveryConfig {
+  id: string;
+  baselineVersion: string;
+  
+  // Change Detection
+  changeDetectionStrategy: ChangeDetectionStrategy;
+  changeThreshold: number;
+  
+  // Optimization
+  optimizationLevel: OptimizationLevel;
+  
+  // Scheduling
+  incrementalSchedule: IncrementalSchedule;
+  
+  // Performance
+  maxChangesToProcess: number;
+  batchSize: number;
+}
+
+export interface DiscoveryDelta {
+  id: string;
+  fromVersion: string;
+  toVersion: string;
+  
+  // Changes
+  addedAssets: string[];
+  modifiedAssets: AssetModification[];
+  removedAssets: string[];
+  
+  // Schema Changes
+  schemaChanges: SchemaChange[];
+  
+  // Lineage Changes
+  lineageChanges: LineageChange[];
+  
+  // Impact Analysis
+  impactAnalysis: DiscoveryImpactAnalysis;
+  
+  // Timestamps
+  detectedAt: Date;
+  processedAt?: Date;
+}
+
+// ============================================================================
+// SCHEMA EVOLUTION & COMPATIBILITY
+// ============================================================================
+
+export interface SchemaEvolution {
+  id: string;
+  version: string;
+  previousVersion?: string;
+  
+  // Changes
+  changes: SchemaChange[];
+  changeType: SchemaChangeType;
+  
+  // Compatibility
+  compatibilityLevel: CompatibilityLevel;
+  breakingChanges: BreakingChange[];
+  
+  // Impact
+  impactedAssets: string[];
+  riskLevel: RiskLevel;
+  
+  // Migration
+  migrationRequired: boolean;
+  migrationStrategy?: MigrationStrategy;
+  
+  // Timestamps
+  evolutionDate: Date;
+  detectedAt: Date;
+}
+
+export interface SchemaChange {
+  changeType: SchemaChangeType;
+  elementType: SchemaElementType;
+  elementName: string;
+  
+  // Change Details
+  oldValue?: any;
+  newValue?: any;
+  
+  // Impact
+  impactLevel: ImpactLevel;
+  affectedComponents: string[];
+  
+  // Compatibility
+  compatibilityImpact: CompatibilityImpact;
+  
+  // Recommendations
+  recommendations: ChangeRecommendation[];
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum DiscoverySourceType {
+  DATABASE = 'DATABASE',
+  FILE_SYSTEM = 'FILE_SYSTEM',
+  CLOUD_STORAGE = 'CLOUD_STORAGE',
+  API = 'API',
+  STREAMING = 'STREAMING',
+  DATA_WAREHOUSE = 'DATA_WAREHOUSE',
+  DATA_LAKE = 'DATA_LAKE',
+  NOSQL = 'NOSQL'
+}
+
+export enum DiscoveryJobStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  PAUSED = 'PAUSED'
+}
+
+export enum DiscoveryPhase {
+  INITIALIZATION = 'INITIALIZATION',
+  SCHEMA_DISCOVERY = 'SCHEMA_DISCOVERY',
+  DATA_PROFILING = 'DATA_PROFILING',
+  CLASSIFICATION = 'CLASSIFICATION',
+  LINEAGE_DISCOVERY = 'LINEAGE_DISCOVERY',
+  QUALITY_ASSESSMENT = 'QUALITY_ASSESSMENT',
+  METADATA_ENRICHMENT = 'METADATA_ENRICHMENT',
+  FINALIZATION = 'FINALIZATION'
+}
+
+export enum DiscoveryMethod {
+  SCHEMA_ANALYSIS = 'SCHEMA_ANALYSIS',
+  DATA_SAMPLING = 'DATA_SAMPLING',
+  PATTERN_MATCHING = 'PATTERN_MATCHING',
+  ML_CLASSIFICATION = 'ML_CLASSIFICATION',
+  RULE_BASED = 'RULE_BASED',
+  METADATA_INSPECTION = 'METADATA_INSPECTION',
+  LINEAGE_TRACING = 'LINEAGE_TRACING'
+}
+
+export enum ClassificationMethod {
+  RULE_BASED = 'RULE_BASED',
+  PATTERN_MATCHING = 'PATTERN_MATCHING',
+  MACHINE_LEARNING = 'MACHINE_LEARNING',
+  STATISTICAL_ANALYSIS = 'STATISTICAL_ANALYSIS',
+  SEMANTIC_ANALYSIS = 'SEMANTIC_ANALYSIS',
+  HYBRID = 'HYBRID'
+}
+
+export enum ChangeDetectionStrategy {
+  TIMESTAMP_BASED = 'TIMESTAMP_BASED',
+  CHECKSUM_BASED = 'CHECKSUM_BASED',
+  LOG_BASED = 'LOG_BASED',
+  HYBRID = 'HYBRID'
+}
+
+export enum SchemaChangeType {
+  COLUMN_ADDED = 'COLUMN_ADDED',
+  COLUMN_REMOVED = 'COLUMN_REMOVED',
+  COLUMN_RENAMED = 'COLUMN_RENAMED',
+  COLUMN_TYPE_CHANGED = 'COLUMN_TYPE_CHANGED',
+  COLUMN_CONSTRAINT_CHANGED = 'COLUMN_CONSTRAINT_CHANGED',
+  TABLE_ADDED = 'TABLE_ADDED',
+  TABLE_REMOVED = 'TABLE_REMOVED',
+  TABLE_RENAMED = 'TABLE_RENAMED',
+  INDEX_ADDED = 'INDEX_ADDED',
+  INDEX_REMOVED = 'INDEX_REMOVED'
+}
+
+export enum CompatibilityLevel {
+  FULLY_COMPATIBLE = 'FULLY_COMPATIBLE',
+  BACKWARD_COMPATIBLE = 'BACKWARD_COMPATIBLE',
+  FORWARD_COMPATIBLE = 'FORWARD_COMPATIBLE',
+  BREAKING_CHANGE = 'BREAKING_CHANGE'
+}
+
+export enum AIInsightType {
+  ANOMALY_DETECTION = 'ANOMALY_DETECTION',
+  PATTERN_RECOGNITION = 'PATTERN_RECOGNITION',
+  QUALITY_ASSESSMENT = 'QUALITY_ASSESSMENT',
+  OPTIMIZATION_OPPORTUNITY = 'OPTIMIZATION_OPPORTUNITY',
+  COMPLIANCE_RISK = 'COMPLIANCE_RISK',
+  USAGE_RECOMMENDATION = 'USAGE_RECOMMENDATION'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface DiscoveryProgress {
+  totalSteps: number;
+  completedSteps: number;
+  currentStep: string;
+  percentage: number;
+  
+  // Phase Progress
+  phaseProgress: PhaseProgress[];
+  
+  // Estimates
+  estimatedTimeRemaining: number;
+  estimatedCompletion: Date;
+}
+
+export interface DiscoveryPerformance {
+  throughput: number;
+  averageProcessingTime: number;
+  memoryUsage: number;
+  cpuUsage: number;
+  
+  // Bottlenecks
+  bottlenecks: PerformanceBottleneck[];
+  
+  // Optimization Suggestions
+  optimizationSuggestions: OptimizationSuggestion[];
+}
+
+export interface DataPattern {
+  patternType: string;
+  pattern: string;
+  frequency: number;
+  examples: string[];
+  confidence: number;
+}
+
+export interface DataAnomaly {
+  anomalyType: string;
+  description: string;
+  severity: string;
+  affectedRows: number;
+  examples: any[];
+  recommendations: string[];
+}
+
+export interface ValueDistribution {
+  distributionType: string;
+  parameters: Record<string, number>;
+  goodnesOfFit: number;
+  outliers: OutlierInfo[];
+}
+
+export interface HistogramBin {
+  lowerBound: number;
+  upperBound: number;
+  count: number;
+  percentage: number;
+}
+
+export interface ValueFrequency {
+  value: any;
+  count: number;
+  percentage: number;
+}
+
+export interface DiscoveryCredentials {
+  type: CredentialType;
+  username?: string;
+  password?: string;
+  token?: string;
+  keyFile?: string;
+  connectionProperties?: Record<string, string>;
+}
+
+export interface SourceConfig {
+  includePatterns: string[];
+  excludePatterns: string[];
+  maxDepth: number;
+  samplingRate: number;
+  customProperties: Record<string, any>;
+}
+
+export enum CredentialType {
+  USERNAME_PASSWORD = 'USERNAME_PASSWORD',
+  TOKEN = 'TOKEN',
+  KEY_FILE = 'KEY_FILE',
+  IAM_ROLE = 'IAM_ROLE',
+  SERVICE_PRINCIPAL = 'SERVICE_PRINCIPAL'
+}
+
+export enum DiscoveryPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT'
+}
+
+export enum SourceStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  ERROR = 'ERROR',
+  SCANNING = 'SCANNING'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/index.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/index.ts
@@ -1,0 +1,459 @@
+// ============================================================================
+// ADVANCED CATALOG TYPES INDEX - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Centralized export for all Advanced-Catalog TypeScript types
+// ============================================================================
+
+// =============================================================================
+// CORE CATALOG TYPES
+// =============================================================================
+export * from './catalog-core.types';
+
+// =============================================================================
+// DISCOVERY TYPES
+// =============================================================================
+export * from './discovery.types';
+
+// =============================================================================
+// QUALITY TYPES
+// =============================================================================
+export * from './quality.types';
+
+// =============================================================================
+// ANALYTICS TYPES
+// =============================================================================
+export * from './analytics.types';
+
+// =============================================================================
+// LINEAGE TYPES
+// =============================================================================
+export * from './lineage.types';
+
+// =============================================================================
+// SEARCH TYPES
+// =============================================================================
+export * from './search.types';
+
+// =============================================================================
+// COLLABORATION TYPES
+// =============================================================================
+export * from './collaboration.types';
+
+// =============================================================================
+// METADATA & GOVERNANCE TYPES
+// =============================================================================
+export * from './metadata.types';
+
+// =============================================================================
+// COMMON UTILITY TYPES
+// =============================================================================
+
+// Generic API Response wrapper
+export interface ApiResponse<T> {
+  data: T;
+  success: boolean;
+  message?: string;
+  errors?: string[];
+  timestamp: Date;
+  requestId: string;
+}
+
+// Generic Pagination
+export interface Pagination {
+  page: number;
+  size: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+// Generic Sort Options
+export interface SortOption {
+  field: string;
+  direction: 'ASC' | 'DESC';
+}
+
+// Generic Filter
+export interface GenericFilter {
+  field: string;
+  operator: 'EQUALS' | 'NOT_EQUALS' | 'CONTAINS' | 'IN' | 'BETWEEN' | 'GREATER_THAN' | 'LESS_THAN';
+  value: any;
+}
+
+// Time Range
+export interface TimeRange {
+  start: Date;
+  end: Date;
+}
+
+// User Context
+export interface UserContext {
+  userId: string;
+  username: string;
+  email: string;
+  roles: string[];
+  permissions: string[];
+  preferences: Record<string, any>;
+}
+
+// System Context
+export interface SystemContext {
+  environment: string;
+  version: string;
+  buildNumber: string;
+  deploymentId: string;
+  region: string;
+}
+
+// Error Details
+export interface ErrorDetail {
+  code: string;
+  message: string;
+  field?: string;
+  details?: Record<string, any>;
+}
+
+// Validation Result
+export interface ValidationResult {
+  valid: boolean;
+  errors: ErrorDetail[];
+  warnings: ErrorDetail[];
+}
+
+// Progress Indicator
+export interface ProgressIndicator {
+  percentage: number;
+  currentStep: string;
+  totalSteps: number;
+  completedSteps: number;
+  estimatedTimeRemaining?: number;
+  message?: string;
+}
+
+// Health Check Result
+export interface HealthCheckResult {
+  status: 'HEALTHY' | 'DEGRADED' | 'UNHEALTHY';
+  checks: HealthCheck[];
+  timestamp: Date;
+  version: string;
+}
+
+export interface HealthCheck {
+  name: string;
+  status: 'PASS' | 'WARN' | 'FAIL';
+  duration: number;
+  message?: string;
+  details?: Record<string, any>;
+}
+
+// Notification
+export interface Notification {
+  id: string;
+  type: 'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR';
+  title: string;
+  message: string;
+  timestamp: Date;
+  read: boolean;
+  actions?: NotificationAction[];
+}
+
+export interface NotificationAction {
+  id: string;
+  label: string;
+  action: string;
+  primary?: boolean;
+}
+
+// Audit Entry
+export interface AuditEntry {
+  id: string;
+  timestamp: Date;
+  userId: string;
+  action: string;
+  resource: string;
+  resourceId?: string;
+  details?: Record<string, any>;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+// Configuration Setting
+export interface ConfigurationSetting {
+  key: string;
+  value: any;
+  type: 'STRING' | 'NUMBER' | 'BOOLEAN' | 'JSON' | 'ARRAY';
+  description?: string;
+  required: boolean;
+  sensitive: boolean;
+  category: string;
+  validationRules?: ValidationRule[];
+}
+
+export interface ValidationRule {
+  type: 'REQUIRED' | 'MIN_LENGTH' | 'MAX_LENGTH' | 'PATTERN' | 'RANGE' | 'ENUM';
+  value?: any;
+  message?: string;
+}
+
+// Feature Flag
+export interface FeatureFlag {
+  name: string;
+  enabled: boolean;
+  description?: string;
+  rolloutPercentage?: number;
+  conditions?: FeatureFlagCondition[];
+  metadata?: Record<string, any>;
+}
+
+export interface FeatureFlagCondition {
+  type: 'USER' | 'ROLE' | 'ENVIRONMENT' | 'REGION' | 'CUSTOM';
+  operator: 'EQUALS' | 'NOT_EQUALS' | 'IN' | 'NOT_IN' | 'CONTAINS';
+  value: any;
+}
+
+// Performance Metrics
+export interface PerformanceMetric {
+  name: string;
+  value: number;
+  unit: string;
+  timestamp: Date;
+  tags?: Record<string, string>;
+  threshold?: {
+    warning: number;
+    critical: number;
+  };
+}
+
+// Resource Usage
+export interface ResourceUsage {
+  cpu: number;
+  memory: number;
+  disk: number;
+  network: {
+    bytesIn: number;
+    bytesOut: number;
+  };
+  timestamp: Date;
+}
+
+// Cache Statistics
+export interface CacheStatistics {
+  hitRate: number;
+  missRate: number;
+  evictionRate: number;
+  size: number;
+  maxSize: number;
+  memoryUsage: number;
+}
+
+// =============================================================================
+// TYPE GUARDS AND UTILITIES
+// =============================================================================
+
+// Type guard for checking if an object is an API response
+export function isApiResponse<T>(obj: any): obj is ApiResponse<T> {
+  return obj && typeof obj === 'object' && 'success' in obj && 'data' in obj;
+}
+
+// Type guard for checking if an object is an error
+export function isErrorDetail(obj: any): obj is ErrorDetail {
+  return obj && typeof obj === 'object' && 'code' in obj && 'message' in obj;
+}
+
+// Type guard for checking if an object is a validation result
+export function isValidationResult(obj: any): obj is ValidationResult {
+  return obj && typeof obj === 'object' && 'valid' in obj && 'errors' in obj;
+}
+
+// Utility type for making all properties optional recursively
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+// Utility type for making all properties required recursively
+export type DeepRequired<T> = {
+  [P in keyof T]-?: T[P] extends object ? DeepRequired<T[P]> : T[P];
+};
+
+// Utility type for picking properties by value type
+export type PickByType<T, U> = {
+  [K in keyof T as T[K] extends U ? K : never]: T[K];
+};
+
+// Utility type for omitting properties by value type
+export type OmitByType<T, U> = {
+  [K in keyof T as T[K] extends U ? never : K]: T[K];
+};
+
+// Utility type for creating a union of all possible key paths
+export type KeyPath<T> = T extends object ? {
+  [K in keyof T]: K extends string ? K | `${K}.${KeyPath<T[K]>}` : never;
+}[keyof T] : never;
+
+// Utility type for getting the value type at a specific key path
+export type ValueAtPath<T, P extends string> = P extends keyof T
+  ? T[P]
+  : P extends `${infer K}.${infer Rest}`
+  ? K extends keyof T
+    ? ValueAtPath<T[K], Rest>
+    : never
+  : never;
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+// Default pagination settings
+export const DEFAULT_PAGINATION = {
+  page: 1,
+  size: 20,
+  maxSize: 100
+} as const;
+
+// Common date formats
+export const DATE_FORMATS = {
+  ISO: 'YYYY-MM-DDTHH:mm:ss.SSSZ',
+  DATE_ONLY: 'YYYY-MM-DD',
+  TIME_ONLY: 'HH:mm:ss',
+  HUMAN_READABLE: 'MMM DD, YYYY HH:mm:ss',
+  SHORT: 'MM/DD/YYYY'
+} as const;
+
+// HTTP Status Codes
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503
+} as const;
+
+// Common MIME types
+export const MIME_TYPES = {
+  JSON: 'application/json',
+  XML: 'application/xml',
+  CSV: 'text/csv',
+  PDF: 'application/pdf',
+  EXCEL: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ZIP: 'application/zip',
+  TEXT: 'text/plain'
+} as const;
+
+// =============================================================================
+// BRAND TYPES FOR TYPE SAFETY
+// =============================================================================
+
+// Branded types for preventing accidental mixing of similar primitive types
+export type AssetId = string & { readonly brand: unique symbol };
+export type UserId = string & { readonly brand: unique symbol };
+export type SessionId = string & { readonly brand: unique symbol };
+export type RequestId = string & { readonly brand: unique symbol };
+export type CorrelationId = string & { readonly brand: unique symbol };
+
+// Helper functions to create branded types
+export const createAssetId = (id: string): AssetId => id as AssetId;
+export const createUserId = (id: string): UserId => id as UserId;
+export const createSessionId = (id: string): SessionId => id as SessionId;
+export const createRequestId = (id: string): RequestId => id as RequestId;
+export const createCorrelationId = (id: string): CorrelationId => id as CorrelationId;
+
+// =============================================================================
+// ENVIRONMENT TYPES
+// =============================================================================
+
+export type Environment = 'development' | 'staging' | 'production' | 'test';
+
+export interface EnvironmentConfig {
+  name: Environment;
+  apiBaseUrl: string;
+  wsBaseUrl: string;
+  enableDebug: boolean;
+  enableAnalytics: boolean;
+  logLevel: 'debug' | 'info' | 'warn' | 'error';
+  features: Record<string, boolean>;
+}
+
+// =============================================================================
+// EVENT TYPES
+// =============================================================================
+
+export interface DomainEvent {
+  id: string;
+  type: string;
+  aggregateId: string;
+  aggregateType: string;
+  version: number;
+  data: Record<string, any>;
+  metadata: EventMetadata;
+  timestamp: Date;
+}
+
+export interface EventMetadata {
+  correlationId?: string;
+  causationId?: string;
+  userId?: string;
+  traceId?: string;
+  source: string;
+}
+
+// =============================================================================
+// COMMAND TYPES
+// =============================================================================
+
+export interface Command {
+  id: string;
+  type: string;
+  aggregateId: string;
+  payload: Record<string, any>;
+  metadata: CommandMetadata;
+}
+
+export interface CommandMetadata {
+  correlationId?: string;
+  userId?: string;
+  timestamp: Date;
+  version?: number;
+}
+
+export interface CommandResult<T = any> {
+  success: boolean;
+  data?: T;
+  events?: DomainEvent[];
+  errors?: ErrorDetail[];
+}
+
+// =============================================================================
+// QUERY TYPES
+// =============================================================================
+
+export interface Query {
+  type: string;
+  parameters: Record<string, any>;
+  metadata: QueryMetadata;
+}
+
+export interface QueryMetadata {
+  correlationId?: string;
+  userId?: string;
+  timestamp: Date;
+  timeout?: number;
+}
+
+export interface QueryResult<T = any> {
+  data: T;
+  metadata: QueryResultMetadata;
+}
+
+export interface QueryResultMetadata {
+  executionTime: number;
+  cacheHit: boolean;
+  pagination?: Pagination;
+  totalCount?: number;
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/lineage.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/lineage.types.ts
@@ -1,0 +1,797 @@
+// ============================================================================
+// ADVANCED CATALOG LINEAGE TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: advanced_lineage_service.py, lineage_service.py, data_lineage_models.py
+// ============================================================================
+
+import { 
+  EnterpriseDataLineage, 
+  DataLineageNode, 
+  DataLineageEdge,
+  IntelligentDataAsset,
+  TimePeriod 
+} from './catalog-core.types';
+
+// ============================================================================
+// ADVANCED LINEAGE TYPES (advanced_lineage_service.py)
+// ============================================================================
+
+export interface LineageVisualization {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Visualization Configuration
+  config: LineageVisualizationConfig;
+  
+  // Graph Data
+  nodes: LineageVisualizationNode[];
+  edges: LineageVisualizationEdge[];
+  
+  // Layout Configuration
+  layout: LineageLayoutConfig;
+  
+  // Filters & Views
+  filters: LineageFilter[];
+  views: LineageView[];
+  
+  // Interactive Features
+  interactionConfig: LineageInteractionConfig;
+  
+  // Performance
+  performance: LineageVisualizationPerformance;
+  
+  // Timestamps
+  createdAt: Date;
+  lastUpdated: Date;
+}
+
+export interface LineageVisualizationNode {
+  id: string;
+  assetId: string;
+  nodeType: LineageNodeType;
+  
+  // Visual Properties
+  position: NodePosition;
+  style: NodeStyle;
+  
+  // Node Data
+  data: LineageNodeData;
+  
+  // Metadata
+  metadata: LineageNodeMetadata;
+  
+  // State
+  state: LineageNodeState;
+  
+  // Interactions
+  interactions: NodeInteraction[];
+}
+
+export interface LineageVisualizationEdge {
+  id: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  
+  // Edge Properties
+  edgeType: LineageEdgeType;
+  transformationType: TransformationType;
+  
+  // Visual Properties
+  style: EdgeStyle;
+  path?: EdgePath;
+  
+  // Edge Data
+  data: LineageEdgeData;
+  
+  // Metadata
+  metadata: LineageEdgeMetadata;
+  
+  // State
+  state: LineageEdgeState;
+  
+  // Confidence & Quality
+  confidence: number;
+  quality: LineageQuality;
+}
+
+export interface LineageTraversalEngine {
+  id: string;
+  name: string;
+  
+  // Traversal Configuration
+  config: TraversalConfig;
+  
+  // Traversal Algorithms
+  algorithms: TraversalAlgorithm[];
+  
+  // Path Finding
+  pathFinder: LineagePathFinder;
+  
+  // Impact Analysis
+  impactAnalyzer: LineageImpactAnalyzer;
+  
+  // Performance
+  performance: TraversalPerformance;
+  
+  // Cache
+  cache: TraversalCache;
+}
+
+export interface LineageImpactAnalysis {
+  id: string;
+  sourceAssetId: string;
+  analysisType: ImpactAnalysisType;
+  
+  // Impact Results
+  impactedAssets: ImpactedAsset[];
+  impactRadius: number;
+  
+  // Impact Categories
+  directImpacts: DirectImpact[];
+  indirectImpacts: IndirectImpact[];
+  cascadingImpacts: CascadingImpact[];
+  
+  // Risk Assessment
+  riskAssessment: LineageRiskAssessment;
+  
+  // Business Impact
+  businessImpact: LineageBusinessImpact;
+  
+  // Technical Impact
+  technicalImpact: LineageTechnicalImpact;
+  
+  // Recommendations
+  mitigationRecommendations: MitigationRecommendation[];
+  
+  // Analysis Metadata
+  analysisMetadata: ImpactAnalysisMetadata;
+  
+  // Timestamps
+  analyzedAt: Date;
+  validUntil?: Date;
+}
+
+export interface LineageGovernance {
+  id: string;
+  name: string;
+  
+  // Governance Policies
+  policies: LineageGovernancePolicy[];
+  
+  // Quality Standards
+  qualityStandards: LineageQualityStandard[];
+  
+  // Validation Rules
+  validationRules: LineageValidationRule[];
+  
+  // Compliance Requirements
+  complianceRequirements: LineageComplianceRequirement[];
+  
+  // Monitoring
+  monitoring: LineageGovernanceMonitoring;
+  
+  // Audit Trail
+  auditTrail: LineageAuditEvent[];
+  
+  // Metrics
+  governanceMetrics: LineageGovernanceMetric[];
+}
+
+// ============================================================================
+// LINEAGE DISCOVERY & TRACKING TYPES
+// ============================================================================
+
+export interface LineageDiscoveryJob {
+  id: string;
+  name: string;
+  status: LineageDiscoveryStatus;
+  
+  // Discovery Configuration
+  config: LineageDiscoveryConfig;
+  
+  // Scope
+  scope: LineageDiscoveryScope;
+  
+  // Execution
+  startTime: Date;
+  endTime?: Date;
+  duration?: number;
+  progress: LineageDiscoveryProgress;
+  
+  // Results
+  results: LineageDiscoveryResults;
+  
+  // Performance
+  performance: LineageDiscoveryPerformance;
+  
+  // Errors & Warnings
+  errors: LineageDiscoveryError[];
+  warnings: LineageDiscoveryWarning[];
+}
+
+export interface LineageDiscoveryResults {
+  totalLineagesDiscovered: number;
+  newLineagesFound: number;
+  existingLineagesUpdated: number;
+  invalidLineagesRemoved: number;
+  
+  // Discovery Breakdown
+  discoveryByMethod: DiscoveryMethodBreakdown[];
+  discoveryByType: LineageTypeBreakdown[];
+  
+  // Quality Metrics
+  averageConfidence: number;
+  highConfidenceLineages: number;
+  
+  // Detailed Results
+  discoveredLineages: DiscoveredLineageRelation[];
+  updatedLineages: UpdatedLineageRelation[];
+  
+  // Performance
+  discoveryRate: number;
+  processingTime: number;
+}
+
+export interface LineageTracking {
+  id: string;
+  assetId: string;
+  
+  // Tracking Configuration
+  config: LineageTrackingConfig;
+  
+  // Change Detection
+  changeDetection: LineageChangeDetection;
+  
+  // Evolution History
+  evolutionHistory: LineageEvolution[];
+  
+  // Monitoring
+  monitoring: LineageMonitoring;
+  
+  // Alerts
+  alerts: LineageAlert[];
+  
+  // Performance
+  performance: LineageTrackingPerformance;
+}
+
+export interface LineageEvolution {
+  id: string;
+  lineageId: string;
+  evolutionType: LineageEvolutionType;
+  
+  // Change Details
+  changes: LineageChange[];
+  changeReason: LineageChangeReason;
+  
+  // Impact
+  impact: LineageEvolutionImpact;
+  
+  // Validation
+  validated: boolean;
+  validationResults: LineageValidationResult[];
+  
+  // Timestamps
+  evolvedAt: Date;
+  detectedAt: Date;
+  validatedAt?: Date;
+}
+
+// ============================================================================
+// LINEAGE QUALITY & VALIDATION TYPES
+// ============================================================================
+
+export interface LineageQualityAssessment {
+  id: string;
+  lineageId: string;
+  assessmentType: LineageQualityAssessmentType;
+  
+  // Quality Dimensions
+  completeness: LineageCompleteness;
+  accuracy: LineageAccuracy;
+  consistency: LineageConsistency;
+  freshness: LineageFreshness;
+  
+  // Overall Quality
+  overallScore: number;
+  qualityGrade: LineageQualityGrade;
+  
+  // Quality Issues
+  issues: LineageQualityIssue[];
+  
+  // Improvements
+  improvements: LineageQualityImprovement[];
+  
+  // Recommendations
+  recommendations: LineageQualityRecommendation[];
+  
+  // Timestamps
+  assessedAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface LineageValidationEngine {
+  id: string;
+  name: string;
+  version: string;
+  
+  // Validation Rules
+  rules: LineageValidationRule[];
+  
+  // Validation Methods
+  methods: LineageValidationMethod[];
+  
+  // Configuration
+  config: ValidationEngineConfig;
+  
+  // Performance
+  performance: ValidationEnginePerformance;
+  
+  // Metrics
+  metrics: ValidationEngineMetric[];
+}
+
+export interface LineageValidationResult {
+  id: string;
+  lineageId: string;
+  validationRuleId: string;
+  
+  // Validation Outcome
+  passed: boolean;
+  score: number;
+  confidence: number;
+  
+  // Details
+  details: ValidationDetails;
+  evidence: ValidationEvidence[];
+  
+  // Issues Found
+  issues: ValidationIssue[];
+  
+  // Recommendations
+  recommendations: ValidationRecommendation[];
+  
+  // Performance
+  validationDuration: number;
+  
+  // Timestamps
+  validatedAt: Date;
+}
+
+// ============================================================================
+// LINEAGE ANALYTICS & INSIGHTS TYPES
+// ============================================================================
+
+export interface LineageAnalytics {
+  id: string;
+  name: string;
+  
+  // Analytics Configuration
+  config: LineageAnalyticsConfig;
+  
+  // Network Analytics
+  networkAnalytics: LineageNetworkAnalytics;
+  
+  // Flow Analytics
+  flowAnalytics: LineageFlowAnalytics;
+  
+  // Pattern Analytics
+  patternAnalytics: LineagePatternAnalytics;
+  
+  // Impact Analytics
+  impactAnalytics: LineageImpactAnalytics;
+  
+  // Trend Analytics
+  trendAnalytics: LineageTrendAnalytics;
+  
+  // Insights
+  insights: LineageAnalyticsInsight[];
+  
+  // Performance
+  performance: LineageAnalyticsPerformance;
+}
+
+export interface LineageNetworkAnalytics {
+  id: string;
+  
+  // Network Metrics
+  totalNodes: number;
+  totalEdges: number;
+  networkDensity: number;
+  
+  // Centrality Metrics
+  centralityMetrics: CentralityMetric[];
+  
+  // Clustering
+  clusteringCoefficient: number;
+  clusters: LineageCluster[];
+  
+  // Connectivity
+  connectivity: NetworkConnectivity;
+  
+  // Path Analytics
+  pathAnalytics: NetworkPathAnalytics;
+  
+  // Robustness
+  robustness: NetworkRobustness;
+}
+
+export interface LineageFlowAnalytics {
+  id: string;
+  
+  // Flow Metrics
+  totalFlows: number;
+  activeFlows: number;
+  flowVelocity: number;
+  
+  // Flow Patterns
+  flowPatterns: FlowPattern[];
+  
+  // Bottlenecks
+  bottlenecks: FlowBottleneck[];
+  
+  // Flow Quality
+  flowQuality: FlowQualityMetric[];
+  
+  // Throughput
+  throughput: FlowThroughput;
+  
+  // Performance
+  flowPerformance: FlowPerformanceMetric[];
+}
+
+export interface LineagePatternAnalytics {
+  id: string;
+  
+  // Common Patterns
+  commonPatterns: LineagePattern[];
+  
+  // Anti-patterns
+  antiPatterns: LineageAntiPattern[];
+  
+  // Pattern Frequency
+  patternFrequency: PatternFrequencyAnalysis;
+  
+  // Pattern Evolution
+  patternEvolution: PatternEvolutionAnalysis;
+  
+  // Best Practices
+  bestPractices: LineageBestPractice[];
+  
+  // Recommendations
+  patternRecommendations: PatternRecommendation[];
+}
+
+// ============================================================================
+// LINEAGE REPORTING TYPES
+// ============================================================================
+
+export interface LineageReport {
+  id: string;
+  name: string;
+  type: LineageReportType;
+  
+  // Report Configuration
+  config: LineageReportConfig;
+  
+  // Content
+  content: LineageReportContent;
+  
+  // Visualizations
+  visualizations: LineageVisualization[];
+  
+  // Metadata
+  metadata: LineageReportMetadata;
+  
+  // Distribution
+  distribution: LineageReportDistribution;
+  
+  // Status
+  status: LineageReportStatus;
+  
+  // Timestamps
+  generatedAt: Date;
+  lastUpdated: Date;
+}
+
+export interface LineageDocumentation {
+  id: string;
+  lineageId: string;
+  
+  // Documentation Content
+  description: string;
+  businessContext: string;
+  technicalDetails: string;
+  
+  // Transformation Logic
+  transformationLogic: TransformationDocumentation[];
+  
+  // Data Flow
+  dataFlow: DataFlowDocumentation;
+  
+  // Dependencies
+  dependencies: DependencyDocumentation[];
+  
+  // Quality Notes
+  qualityNotes: QualityDocumentation[];
+  
+  // Maintenance
+  maintenanceNotes: MaintenanceDocumentation[];
+  
+  // Version Control
+  version: string;
+  changeLog: DocumentationChangeLog[];
+  
+  // Approval
+  approvalStatus: DocumentationApprovalStatus;
+  approvedBy?: string;
+  approvedAt?: Date;
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum LineageNodeType {
+  SOURCE = 'SOURCE',
+  TARGET = 'TARGET',
+  TRANSFORMATION = 'TRANSFORMATION',
+  AGGREGATION = 'AGGREGATION',
+  FILTER = 'FILTER',
+  JOIN = 'JOIN',
+  UNION = 'UNION',
+  SPLIT = 'SPLIT'
+}
+
+export enum LineageEdgeType {
+  DATA_FLOW = 'DATA_FLOW',
+  TRANSFORMATION = 'TRANSFORMATION',
+  DEPENDENCY = 'DEPENDENCY',
+  TRIGGER = 'TRIGGER',
+  CONTROL_FLOW = 'CONTROL_FLOW'
+}
+
+export enum TransformationType {
+  COPY = 'COPY',
+  FILTER = 'FILTER',
+  AGGREGATE = 'AGGREGATE',
+  JOIN = 'JOIN',
+  UNION = 'UNION',
+  TRANSFORM = 'TRANSFORM',
+  CALCULATE = 'CALCULATE',
+  SPLIT = 'SPLIT',
+  MERGE = 'MERGE',
+  CLEANSE = 'CLEANSE'
+}
+
+export enum LineageDiscoveryStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  PAUSED = 'PAUSED'
+}
+
+export enum ImpactAnalysisType {
+  DOWNSTREAM = 'DOWNSTREAM',
+  UPSTREAM = 'UPSTREAM',
+  BIDIRECTIONAL = 'BIDIRECTIONAL',
+  COMPREHENSIVE = 'COMPREHENSIVE'
+}
+
+export enum LineageEvolutionType {
+  CREATION = 'CREATION',
+  MODIFICATION = 'MODIFICATION',
+  DELETION = 'DELETION',
+  SCHEMA_CHANGE = 'SCHEMA_CHANGE',
+  TRANSFORMATION_CHANGE = 'TRANSFORMATION_CHANGE',
+  DEPENDENCY_CHANGE = 'DEPENDENCY_CHANGE'
+}
+
+export enum LineageQualityGrade {
+  EXCELLENT = 'EXCELLENT',
+  GOOD = 'GOOD',
+  FAIR = 'FAIR',
+  POOR = 'POOR',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum LineageQualityAssessmentType {
+  AUTOMATED = 'AUTOMATED',
+  MANUAL = 'MANUAL',
+  HYBRID = 'HYBRID',
+  CONTINUOUS = 'CONTINUOUS'
+}
+
+export enum LineageReportType {
+  SUMMARY = 'SUMMARY',
+  DETAILED = 'DETAILED',
+  IMPACT_ANALYSIS = 'IMPACT_ANALYSIS',
+  QUALITY_REPORT = 'QUALITY_REPORT',
+  COMPLIANCE_REPORT = 'COMPLIANCE_REPORT',
+  PERFORMANCE_REPORT = 'PERFORMANCE_REPORT'
+}
+
+export enum LineageReportStatus {
+  GENERATING = 'GENERATING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  SCHEDULED = 'SCHEDULED'
+}
+
+export enum DocumentationApprovalStatus {
+  DRAFT = 'DRAFT',
+  PENDING_REVIEW = 'PENDING_REVIEW',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  NEEDS_UPDATE = 'NEEDS_UPDATE'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface NodePosition {
+  x: number;
+  y: number;
+  z?: number;
+}
+
+export interface NodeStyle {
+  color: string;
+  size: number;
+  shape: NodeShape;
+  icon?: string;
+  label?: NodeLabel;
+  border?: NodeBorder;
+}
+
+export interface EdgeStyle {
+  color: string;
+  width: number;
+  style: EdgeLineStyle;
+  arrow?: EdgeArrow;
+  label?: EdgeLabel;
+}
+
+export interface LineageNodeData {
+  asset: IntelligentDataAsset;
+  transformations: any[];
+  metadata: Record<string, any>;
+  metrics: Record<string, number>;
+}
+
+export interface LineageEdgeData {
+  transformation: any;
+  metadata: Record<string, any>;
+  metrics: Record<string, number>;
+  confidence: number;
+}
+
+export interface LineageFilter {
+  id: string;
+  name: string;
+  type: FilterType;
+  criteria: FilterCriteria;
+  enabled: boolean;
+}
+
+export interface LineageView {
+  id: string;
+  name: string;
+  description?: string;
+  filters: LineageFilter[];
+  layout: LineageLayoutConfig;
+  customizations: ViewCustomization[];
+}
+
+export interface ImpactedAsset {
+  assetId: string;
+  asset: IntelligentDataAsset;
+  impactLevel: ImpactLevel;
+  impactType: ImpactType;
+  distance: number;
+  pathCount: number;
+  riskLevel: RiskLevel;
+}
+
+export interface LineageCluster {
+  id: string;
+  name: string;
+  nodes: string[];
+  density: number;
+  cohesion: number;
+  purpose: ClusterPurpose;
+}
+
+export interface FlowPattern {
+  id: string;
+  type: FlowPatternType;
+  frequency: number;
+  strength: number;
+  examples: FlowPatternExample[];
+}
+
+export interface LineagePattern {
+  id: string;
+  name: string;
+  type: PatternType;
+  description: string;
+  frequency: number;
+  examples: PatternExample[];
+  bestPractice: boolean;
+}
+
+export enum NodeShape {
+  CIRCLE = 'CIRCLE',
+  SQUARE = 'SQUARE',
+  DIAMOND = 'DIAMOND',
+  TRIANGLE = 'TRIANGLE',
+  HEXAGON = 'HEXAGON'
+}
+
+export enum EdgeLineStyle {
+  SOLID = 'SOLID',
+  DASHED = 'DASHED',
+  DOTTED = 'DOTTED',
+  CURVED = 'CURVED'
+}
+
+export enum FilterType {
+  ASSET_TYPE = 'ASSET_TYPE',
+  TRANSFORMATION_TYPE = 'TRANSFORMATION_TYPE',
+  CONFIDENCE_LEVEL = 'CONFIDENCE_LEVEL',
+  TIME_RANGE = 'TIME_RANGE',
+  BUSINESS_DOMAIN = 'BUSINESS_DOMAIN'
+}
+
+export enum ImpactLevel {
+  MINIMAL = 'MINIMAL',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum ImpactType {
+  DIRECT = 'DIRECT',
+  INDIRECT = 'INDIRECT',
+  CASCADING = 'CASCADING',
+  SYSTEMIC = 'SYSTEMIC'
+}
+
+export enum RiskLevel {
+  VERY_LOW = 'VERY_LOW',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  VERY_HIGH = 'VERY_HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum ClusterPurpose {
+  DATA_PROCESSING = 'DATA_PROCESSING',
+  ANALYTICS = 'ANALYTICS',
+  REPORTING = 'REPORTING',
+  INTEGRATION = 'INTEGRATION',
+  ARCHIVE = 'ARCHIVE'
+}
+
+export enum FlowPatternType {
+  SEQUENTIAL = 'SEQUENTIAL',
+  PARALLEL = 'PARALLEL',
+  BRANCHING = 'BRANCHING',
+  MERGING = 'MERGING',
+  CIRCULAR = 'CIRCULAR'
+}
+
+export enum PatternType {
+  ARCHITECTURAL = 'ARCHITECTURAL',
+  PROCESSING = 'PROCESSING',
+  INTEGRATION = 'INTEGRATION',
+  QUALITY = 'QUALITY',
+  GOVERNANCE = 'GOVERNANCE'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/metadata.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/metadata.types.ts
@@ -1,0 +1,909 @@
+// ============================================================================
+// ADVANCED CATALOG METADATA & GOVERNANCE TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: Metadata management and governance features across backend services
+// ============================================================================
+
+import { 
+  IntelligentDataAsset, 
+  BusinessGlossaryTerm,
+  TimePeriod 
+} from './catalog-core.types';
+
+// ============================================================================
+// METADATA MANAGEMENT TYPES
+// ============================================================================
+
+export interface MetadataManager {
+  id: string;
+  name: string;
+  
+  // Metadata Configuration
+  config: MetadataManagerConfig;
+  
+  // Schema Management
+  schemaRegistry: MetadataSchemaRegistry;
+  
+  // Metadata Store
+  metadataStore: MetadataStore;
+  
+  // Enrichment Engine
+  enrichmentEngine: MetadataEnrichmentEngine;
+  
+  // Validation Engine
+  validationEngine: MetadataValidationEngine;
+  
+  // Synchronization
+  synchronization: MetadataSynchronization;
+  
+  // Analytics
+  analytics: MetadataAnalytics;
+  
+  // Quality Control
+  qualityControl: MetadataQualityControl;
+}
+
+export interface MetadataSchemaRegistry {
+  id: string;
+  name: string;
+  
+  // Schema Definitions
+  schemas: MetadataSchema[];
+  
+  // Schema Versions
+  versions: SchemaVersion[];
+  
+  // Schema Relationships
+  relationships: SchemaRelationship[];
+  
+  // Schema Evolution
+  evolution: SchemaEvolution[];
+  
+  // Validation Rules
+  validationRules: SchemaValidationRule[];
+  
+  // Compliance
+  compliance: SchemaCompliance;
+  
+  // Governance
+  governance: SchemaGovernance;
+}
+
+export interface MetadataSchema {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  
+  // Schema Definition
+  definition: SchemaDefinition;
+  
+  // Fields
+  fields: MetadataField[];
+  
+  // Constraints
+  constraints: MetadataConstraint[];
+  
+  // Validation Rules
+  validationRules: FieldValidationRule[];
+  
+  // Business Rules
+  businessRules: MetadataBusinessRule[];
+  
+  // Inheritance
+  parentSchema?: string;
+  childSchemas: string[];
+  
+  // Lifecycle
+  status: SchemaStatus;
+  lifecycle: SchemaLifecycle;
+  
+  // Governance
+  owner: string;
+  stewards: string[];
+  approvalStatus: ApprovalStatus;
+  
+  // Usage
+  usage: SchemaUsage;
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+  approvedAt?: Date;
+}
+
+export interface MetadataField {
+  id: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  
+  // Field Definition
+  dataType: MetadataFieldType;
+  required: boolean;
+  defaultValue?: any;
+  
+  // Validation
+  validation: FieldValidation;
+  
+  // Enumeration
+  enumeration?: FieldEnumeration;
+  
+  // Relationships
+  relationships: FieldRelationship[];
+  
+  // Business Context
+  businessContext: FieldBusinessContext;
+  
+  // Classification
+  classification: FieldClassification;
+  
+  // Lineage
+  lineage: FieldLineage;
+  
+  // Governance
+  governance: FieldGovernance;
+}
+
+export interface MetadataStore {
+  id: string;
+  name: string;
+  
+  // Store Configuration
+  config: MetadataStoreConfig;
+  
+  // Storage Backend
+  backend: StorageBackend;
+  
+  // Indexing
+  indexing: MetadataIndexing;
+  
+  // Search
+  search: MetadataSearch;
+  
+  // Caching
+  caching: MetadataCaching;
+  
+  // Backup & Recovery
+  backup: MetadataBackup;
+  
+  // Performance
+  performance: StorePerformance;
+  
+  // Security
+  security: StoreSecurity;
+}
+
+export interface MetadataEnrichmentEngine {
+  id: string;
+  name: string;
+  
+  // Enrichment Configuration
+  config: EnrichmentConfig;
+  
+  // Enrichment Sources
+  sources: EnrichmentSource[];
+  
+  // Enrichment Rules
+  rules: EnrichmentRule[];
+  
+  // AI/ML Models
+  models: EnrichmentModel[];
+  
+  // Processing Pipeline
+  pipeline: EnrichmentPipeline;
+  
+  // Quality Control
+  qualityControl: EnrichmentQualityControl;
+  
+  // Performance
+  performance: EnrichmentPerformance;
+  
+  // Analytics
+  analytics: EnrichmentAnalytics;
+}
+
+// ============================================================================
+// GOVERNANCE TYPES
+// ============================================================================
+
+export interface CatalogGovernance {
+  id: string;
+  name: string;
+  
+  // Governance Framework
+  framework: GovernanceFramework;
+  
+  // Policies
+  policies: GovernancePolicy[];
+  
+  // Standards
+  standards: GovernanceStandard[];
+  
+  // Procedures
+  procedures: GovernanceProcedure[];
+  
+  // Roles & Responsibilities
+  roles: GovernanceRole[];
+  responsibilities: GovernanceResponsibility[];
+  
+  // Compliance
+  compliance: GovernanceCompliance;
+  
+  // Monitoring
+  monitoring: GovernanceMonitoring;
+  
+  // Reporting
+  reporting: GovernanceReporting;
+  
+  // Metrics
+  metrics: GovernanceMetric[];
+}
+
+export interface GovernancePolicy {
+  id: string;
+  name: string;
+  description: string;
+  
+  // Policy Definition
+  definition: PolicyDefinition;
+  
+  // Scope
+  scope: PolicyScope;
+  
+  // Rules
+  rules: PolicyRule[];
+  
+  // Enforcement
+  enforcement: PolicyEnforcement;
+  
+  // Compliance
+  compliance: PolicyCompliance;
+  
+  // Exceptions
+  exceptions: PolicyException[];
+  
+  // Lifecycle
+  status: PolicyStatus;
+  version: string;
+  lifecycle: PolicyLifecycle;
+  
+  // Governance
+  owner: string;
+  approvers: string[];
+  
+  // Implementation
+  implementation: PolicyImplementation;
+  
+  // Monitoring
+  monitoring: PolicyMonitoring;
+  
+  // Timestamps
+  createdAt: Date;
+  effectiveFrom: Date;
+  expiresAt?: Date;
+}
+
+export interface GovernanceStandard {
+  id: string;
+  name: string;
+  description: string;
+  
+  // Standard Definition
+  definition: StandardDefinition;
+  
+  // Categories
+  category: StandardCategory;
+  subCategory?: string;
+  
+  // Requirements
+  requirements: StandardRequirement[];
+  
+  // Compliance Criteria
+  complianceCriteria: ComplianceCriteria[];
+  
+  // Assessment
+  assessment: StandardAssessment;
+  
+  // Implementation
+  implementation: StandardImplementation;
+  
+  // Monitoring
+  monitoring: StandardMonitoring;
+  
+  // Certification
+  certification: StandardCertification;
+  
+  // Status
+  status: StandardStatus;
+  
+  // Governance
+  owner: string;
+  stewards: string[];
+}
+
+export interface AccessControlMatrix {
+  id: string;
+  name: string;
+  
+  // Matrix Configuration
+  config: AccessControlConfig;
+  
+  // Subjects
+  subjects: AccessSubject[];
+  
+  // Objects
+  objects: AccessObject[];
+  
+  // Permissions
+  permissions: AccessPermission[];
+  
+  // Rules
+  rules: AccessRule[];
+  
+  // Policies
+  policies: AccessPolicy[];
+  
+  // Context
+  context: AccessContext;
+  
+  // Evaluation
+  evaluation: AccessEvaluation;
+  
+  // Audit
+  audit: AccessAudit;
+}
+
+export interface DataClassificationSystem {
+  id: string;
+  name: string;
+  
+  // Classification Framework
+  framework: ClassificationFramework;
+  
+  // Classification Schemes
+  schemes: ClassificationScheme[];
+  
+  // Classification Rules
+  rules: ClassificationRule[];
+  
+  // Automated Classification
+  automation: AutomatedClassification;
+  
+  // Manual Classification
+  manual: ManualClassification;
+  
+  // Validation
+  validation: ClassificationValidation;
+  
+  // Governance
+  governance: ClassificationGovernance;
+  
+  // Analytics
+  analytics: ClassificationAnalytics;
+}
+
+export interface DataPrivacyManager {
+  id: string;
+  name: string;
+  
+  // Privacy Configuration
+  config: PrivacyConfig;
+  
+  // Privacy Policies
+  policies: PrivacyPolicy[];
+  
+  // PII Detection
+  piiDetection: PIIDetection;
+  
+  // Data Masking
+  dataMasking: DataMasking;
+  
+  // Consent Management
+  consentManagement: ConsentManagement;
+  
+  // Rights Management
+  rightsManagement: RightsManagement;
+  
+  // Compliance
+  compliance: PrivacyCompliance;
+  
+  // Monitoring
+  monitoring: PrivacyMonitoring;
+}
+
+// ============================================================================
+// AUDIT & COMPLIANCE TYPES
+// ============================================================================
+
+export interface AuditTrailManager {
+  id: string;
+  name: string;
+  
+  // Audit Configuration
+  config: AuditConfig;
+  
+  // Audit Events
+  events: AuditEvent[];
+  
+  // Audit Trails
+  trails: AuditTrail[];
+  
+  // Retention Policies
+  retentionPolicies: AuditRetentionPolicy[];
+  
+  // Search & Query
+  search: AuditSearch;
+  
+  // Reporting
+  reporting: AuditReporting;
+  
+  // Compliance
+  compliance: AuditCompliance;
+  
+  // Security
+  security: AuditSecurity;
+}
+
+export interface AuditEvent {
+  id: string;
+  
+  // Event Information
+  eventType: AuditEventType;
+  eventCategory: AuditEventCategory;
+  
+  // Actor Information
+  actorId: string;
+  actorType: ActorType;
+  actorDetails: ActorDetails;
+  
+  // Target Information
+  targetId: string;
+  targetType: TargetType;
+  targetDetails: TargetDetails;
+  
+  // Action Information
+  action: AuditAction;
+  actionDetails: ActionDetails;
+  
+  // Context
+  context: AuditContext;
+  
+  // Results
+  result: AuditResult;
+  
+  // Risk Assessment
+  riskLevel: RiskLevel;
+  
+  // Compliance
+  complianceImpact: ComplianceImpact;
+  
+  // Timestamps
+  timestamp: Date;
+  duration?: number;
+}
+
+export interface ComplianceManager {
+  id: string;
+  name: string;
+  
+  // Compliance Framework
+  framework: ComplianceFramework;
+  
+  // Regulations
+  regulations: Regulation[];
+  
+  // Compliance Requirements
+  requirements: ComplianceRequirement[];
+  
+  // Controls
+  controls: ComplianceControl[];
+  
+  // Assessments
+  assessments: ComplianceAssessment[];
+  
+  // Monitoring
+  monitoring: ComplianceMonitoring;
+  
+  // Reporting
+  reporting: ComplianceReporting;
+  
+  // Remediation
+  remediation: ComplianceRemediation;
+}
+
+export interface Regulation {
+  id: string;
+  name: string;
+  description: string;
+  
+  // Regulation Details
+  jurisdiction: string;
+  authority: string;
+  effectiveDate: Date;
+  
+  // Requirements
+  requirements: RegulatoryRequirement[];
+  
+  // Compliance Mapping
+  mapping: ComplianceMapping;
+  
+  // Implementation
+  implementation: RegulationImplementation;
+  
+  // Monitoring
+  monitoring: RegulationMonitoring;
+  
+  // Status
+  status: RegulationStatus;
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum MetadataFieldType {
+  STRING = 'STRING',
+  INTEGER = 'INTEGER',
+  FLOAT = 'FLOAT',
+  BOOLEAN = 'BOOLEAN',
+  DATE = 'DATE',
+  DATETIME = 'DATETIME',
+  JSON = 'JSON',
+  ARRAY = 'ARRAY',
+  OBJECT = 'OBJECT',
+  REFERENCE = 'REFERENCE',
+  ENUM = 'ENUM'
+}
+
+export enum SchemaStatus {
+  DRAFT = 'DRAFT',
+  REVIEW = 'REVIEW',
+  APPROVED = 'APPROVED',
+  ACTIVE = 'ACTIVE',
+  DEPRECATED = 'DEPRECATED',
+  RETIRED = 'RETIRED'
+}
+
+export enum PolicyStatus {
+  DRAFT = 'DRAFT',
+  REVIEW = 'REVIEW',
+  APPROVED = 'APPROVED',
+  ACTIVE = 'ACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  RETIRED = 'RETIRED'
+}
+
+export enum StandardCategory {
+  DATA_QUALITY = 'DATA_QUALITY',
+  DATA_SECURITY = 'DATA_SECURITY',
+  DATA_PRIVACY = 'DATA_PRIVACY',
+  DATA_GOVERNANCE = 'DATA_GOVERNANCE',
+  METADATA = 'METADATA',
+  LINEAGE = 'LINEAGE',
+  CLASSIFICATION = 'CLASSIFICATION',
+  COMPLIANCE = 'COMPLIANCE'
+}
+
+export enum StandardStatus {
+  DRAFT = 'DRAFT',
+  REVIEW = 'REVIEW',
+  APPROVED = 'APPROVED',
+  ACTIVE = 'ACTIVE',
+  DEPRECATED = 'DEPRECATED',
+  RETIRED = 'RETIRED'
+}
+
+export enum AuditEventType {
+  CREATE = 'CREATE',
+  READ = 'READ',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+  ACCESS = 'ACCESS',
+  AUTHENTICATION = 'AUTHENTICATION',
+  AUTHORIZATION = 'AUTHORIZATION',
+  EXPORT = 'EXPORT',
+  SHARE = 'SHARE',
+  CLASSIFY = 'CLASSIFY'
+}
+
+export enum AuditEventCategory {
+  SYSTEM = 'SYSTEM',
+  USER = 'USER',
+  DATA = 'DATA',
+  SECURITY = 'SECURITY',
+  COMPLIANCE = 'COMPLIANCE',
+  GOVERNANCE = 'GOVERNANCE',
+  ADMINISTRATIVE = 'ADMINISTRATIVE'
+}
+
+export enum ActorType {
+  USER = 'USER',
+  SYSTEM = 'SYSTEM',
+  SERVICE = 'SERVICE',
+  APPLICATION = 'APPLICATION',
+  API = 'API',
+  PROCESS = 'PROCESS'
+}
+
+export enum TargetType {
+  ASSET = 'ASSET',
+  SCHEMA = 'SCHEMA',
+  FIELD = 'FIELD',
+  POLICY = 'POLICY',
+  RULE = 'RULE',
+  USER = 'USER',
+  ROLE = 'ROLE',
+  PERMISSION = 'PERMISSION'
+}
+
+export enum RiskLevel {
+  VERY_LOW = 'VERY_LOW',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  VERY_HIGH = 'VERY_HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum RegulationStatus {
+  PROPOSED = 'PROPOSED',
+  ENACTED = 'ENACTED',
+  EFFECTIVE = 'EFFECTIVE',
+  AMENDED = 'AMENDED',
+  SUPERSEDED = 'SUPERSEDED',
+  REPEALED = 'REPEALED'
+}
+
+export enum ApprovalStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  NEEDS_REVISION = 'NEEDS_REVISION',
+  CANCELLED = 'CANCELLED'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface MetadataConstraint {
+  id: string;
+  name: string;
+  type: ConstraintType;
+  definition: ConstraintDefinition;
+  validation: ConstraintValidation;
+  enforcement: ConstraintEnforcement;
+}
+
+export interface SchemaValidationRule {
+  id: string;
+  name: string;
+  type: ValidationRuleType;
+  condition: ValidationCondition;
+  action: ValidationAction;
+  severity: ValidationSeverity;
+}
+
+export interface FieldValidation {
+  required: boolean;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  minValue?: number;
+  maxValue?: number;
+  customValidators: CustomValidator[];
+}
+
+export interface EnrichmentSource {
+  id: string;
+  name: string;
+  type: EnrichmentSourceType;
+  config: SourceConfig;
+  priority: number;
+  reliability: number;
+}
+
+export interface GovernanceRole {
+  id: string;
+  name: string;
+  description: string;
+  permissions: RolePermission[];
+  responsibilities: RoleResponsibility[];
+  requirements: RoleRequirement[];
+}
+
+export interface PolicyRule {
+  id: string;
+  name: string;
+  condition: RuleCondition;
+  action: RuleAction;
+  priority: number;
+  enabled: boolean;
+}
+
+export interface AccessSubject {
+  id: string;
+  type: SubjectType;
+  identifier: string;
+  attributes: SubjectAttribute[];
+  roles: string[];
+  groups: string[];
+}
+
+export interface AccessObject {
+  id: string;
+  type: ObjectType;
+  identifier: string;
+  attributes: ObjectAttribute[];
+  classification: ObjectClassification;
+  sensitivity: SensitivityLevel;
+}
+
+export interface AccessPermission {
+  id: string;
+  name: string;
+  description: string;
+  operations: Operation[];
+  constraints: PermissionConstraint[];
+}
+
+export interface ComplianceRequirement {
+  id: string;
+  regulationId: string;
+  name: string;
+  description: string;
+  type: RequirementType;
+  priority: RequirementPriority;
+  controls: string[];
+  evidence: RequirementEvidence[];
+  status: RequirementStatus;
+}
+
+export interface AuditContext {
+  sessionId?: string;
+  requestId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  location?: GeographicLocation;
+  businessContext?: BusinessContext;
+  technicalContext?: TechnicalContext;
+}
+
+export interface AuditResult {
+  success: boolean;
+  errorCode?: string;
+  errorMessage?: string;
+  details?: Record<string, any>;
+  changes?: ChangeRecord[];
+}
+
+export enum ConstraintType {
+  NOT_NULL = 'NOT_NULL',
+  UNIQUE = 'UNIQUE',
+  PRIMARY_KEY = 'PRIMARY_KEY',
+  FOREIGN_KEY = 'FOREIGN_KEY',
+  CHECK = 'CHECK',
+  DEFAULT = 'DEFAULT',
+  RANGE = 'RANGE',
+  PATTERN = 'PATTERN'
+}
+
+export enum ValidationRuleType {
+  FIELD_VALIDATION = 'FIELD_VALIDATION',
+  CROSS_FIELD_VALIDATION = 'CROSS_FIELD_VALIDATION',
+  BUSINESS_RULE = 'BUSINESS_RULE',
+  COMPLIANCE_RULE = 'COMPLIANCE_RULE',
+  QUALITY_RULE = 'QUALITY_RULE'
+}
+
+export enum ValidationSeverity {
+  INFO = 'INFO',
+  WARNING = 'WARNING',
+  ERROR = 'ERROR',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum EnrichmentSourceType {
+  INTERNAL = 'INTERNAL',
+  EXTERNAL = 'EXTERNAL',
+  AI_MODEL = 'AI_MODEL',
+  MANUAL = 'MANUAL',
+  CROWDSOURCED = 'CROWDSOURCED'
+}
+
+export enum SubjectType {
+  USER = 'USER',
+  ROLE = 'ROLE',
+  GROUP = 'GROUP',
+  SERVICE = 'SERVICE',
+  APPLICATION = 'APPLICATION'
+}
+
+export enum ObjectType {
+  ASSET = 'ASSET',
+  FIELD = 'FIELD',
+  SCHEMA = 'SCHEMA',
+  CATALOG = 'CATALOG',
+  WORKSPACE = 'WORKSPACE',
+  REPORT = 'REPORT'
+}
+
+export enum RequirementType {
+  FUNCTIONAL = 'FUNCTIONAL',
+  NON_FUNCTIONAL = 'NON_FUNCTIONAL',
+  SECURITY = 'SECURITY',
+  PRIVACY = 'PRIVACY',
+  AUDIT = 'AUDIT',
+  REPORTING = 'REPORTING'
+}
+
+export enum RequirementPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum RequirementStatus {
+  IDENTIFIED = 'IDENTIFIED',
+  ANALYZED = 'ANALYZED',
+  IMPLEMENTED = 'IMPLEMENTED',
+  TESTED = 'TESTED',
+  VERIFIED = 'VERIFIED',
+  NON_COMPLIANT = 'NON_COMPLIANT'
+}
+
+export enum SensitivityLevel {
+  PUBLIC = 'PUBLIC',
+  INTERNAL = 'INTERNAL',
+  CONFIDENTIAL = 'CONFIDENTIAL',
+  RESTRICTED = 'RESTRICTED',
+  TOP_SECRET = 'TOP_SECRET'
+}
+
+// ============================================================================
+// COMPLEX SUPPORTING TYPES
+// ============================================================================
+
+export interface GeographicLocation {
+  country?: string;
+  region?: string;
+  city?: string;
+  coordinates?: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+export interface BusinessContext {
+  department?: string;
+  businessUnit?: string;
+  project?: string;
+  initiative?: string;
+  process?: string;
+}
+
+export interface TechnicalContext {
+  system?: string;
+  application?: string;
+  service?: string;
+  environment?: string;
+  version?: string;
+}
+
+export interface ChangeRecord {
+  field: string;
+  oldValue?: any;
+  newValue?: any;
+  changeType: ChangeType;
+  timestamp: Date;
+}
+
+export enum ChangeType {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+  MOVE = 'MOVE',
+  RENAME = 'RENAME'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/quality.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/quality.types.ts
@@ -1,0 +1,791 @@
+// ============================================================================
+// ADVANCED CATALOG QUALITY TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: catalog_quality_service.py, catalog_quality_models.py
+// ============================================================================
+
+import { 
+  DataQualityRule, 
+  QualityScorecard,
+  TimePeriod,
+  IntelligentDataAsset 
+} from './catalog-core.types';
+
+// ============================================================================
+// QUALITY MANAGEMENT TYPES (catalog_quality_service.py)
+// ============================================================================
+
+export interface QualityDashboard {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Dashboard Configuration
+  config: QualityDashboardConfig;
+  
+  // Quality Metrics
+  overallQualityScore: number;
+  qualityTrend: QualityTrend;
+  
+  // Widgets
+  widgets: QualityWidget[];
+  
+  // Filters & Time Range
+  filters: QualityFilter[];
+  timeRange: TimePeriod;
+  
+  // Refresh Settings
+  autoRefresh: boolean;
+  refreshInterval: number;
+  lastRefreshed: Date;
+  
+  // User Preferences
+  layout: DashboardLayout;
+  personalizations: DashboardPersonalization[];
+  
+  // Timestamps
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface QualityWidget {
+  id: string;
+  type: QualityWidgetType;
+  title: string;
+  position: WidgetPosition;
+  size: WidgetSize;
+  
+  // Configuration
+  config: WidgetConfig;
+  dataSource: WidgetDataSource;
+  
+  // Data
+  data: QualityWidgetData;
+  
+  // Visualization
+  chartType: ChartType;
+  chartConfig: ChartConfig;
+  
+  // Interactivity
+  drillDownEnabled: boolean;
+  filterEnabled: boolean;
+  
+  // Refresh
+  autoRefresh: boolean;
+  refreshInterval: number;
+  lastRefreshed: Date;
+}
+
+export interface QualityAssessmentJob {
+  id: string;
+  name: string;
+  status: QualityJobStatus;
+  
+  // Scope
+  scope: QualityAssessmentScope;
+  assets: string[];
+  
+  // Configuration
+  rules: DataQualityRule[];
+  schedule: QualitySchedule;
+  
+  // Execution
+  startTime: Date;
+  endTime?: Date;
+  duration?: number;
+  progress: QualityJobProgress;
+  
+  // Results
+  results: QualityAssessmentResult[];
+  summary: QualityJobSummary;
+  
+  // Performance
+  performance: QualityJobPerformance;
+  
+  // Errors
+  errors: QualityJobError[];
+  warnings: QualityJobWarning[];
+}
+
+export interface QualityAssessmentResult {
+  id: string;
+  assetId: string;
+  jobId: string;
+  
+  // Overall Assessment
+  overallScore: number;
+  status: QualityAssessmentStatus;
+  
+  // Dimension Scores
+  dimensionScores: QualityDimensionScore[];
+  
+  // Rule Results
+  ruleResults: QualityRuleExecutionResult[];
+  
+  // Issues Found
+  issues: QualityIssue[];
+  criticalIssues: QualityIssue[];
+  
+  // Trends
+  scoreTrend: QualityScoreTrend;
+  improvement: QualityImprovement;
+  
+  // Recommendations
+  recommendations: QualityRecommendation[];
+  actionItems: QualityActionItem[];
+  
+  // Metadata
+  executionMetadata: QualityExecutionMetadata;
+  
+  // Timestamps
+  assessedAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface QualityRuleExecutionResult {
+  ruleId: string;
+  ruleName: string;
+  status: RuleExecutionStatus;
+  
+  // Execution Details
+  executionTime: Date;
+  duration: number;
+  
+  // Results
+  passed: boolean;
+  score: number;
+  threshold: number;
+  
+  // Metrics
+  recordsProcessed: number;
+  recordsPassed: number;
+  recordsFailed: number;
+  
+  // Issues
+  issues: QualityRuleIssue[];
+  samples: QualityIssueSample[];
+  
+  // Performance
+  performance: RuleExecutionPerformance;
+  
+  // Error Handling
+  errors: RuleExecutionError[];
+  retryCount: number;
+}
+
+export interface QualityIssue {
+  id: string;
+  type: QualityIssueType;
+  severity: QualityIssueSeverity;
+  title: string;
+  description: string;
+  
+  // Context
+  assetId: string;
+  columnName?: string;
+  ruleId?: string;
+  
+  // Details
+  affectedRecords: number;
+  sampleValues: any[];
+  pattern?: string;
+  
+  // Impact
+  businessImpact: BusinessImpact;
+  technicalImpact: TechnicalImpact;
+  
+  // Resolution
+  status: IssueStatus;
+  assignedTo?: string;
+  dueDate?: Date;
+  
+  // Tracking
+  firstDetected: Date;
+  lastSeen: Date;
+  occurrenceCount: number;
+  
+  // Resolution History
+  resolutionHistory: IssueResolution[];
+  
+  // Related Issues
+  relatedIssues: string[];
+  rootCause?: RootCause;
+}
+
+export interface QualityTrend {
+  id: string;
+  assetId?: string;
+  period: TimePeriod;
+  
+  // Trend Data
+  dataPoints: QualityTrendDataPoint[];
+  direction: TrendDirection;
+  
+  // Analysis
+  changeRate: number;
+  volatility: number;
+  seasonality: SeasonalityInfo;
+  
+  // Forecasting
+  forecast: QualityForecast[];
+  
+  // Insights
+  insights: QualityTrendInsight[];
+  
+  // Alerts
+  alerts: QualityTrendAlert[];
+}
+
+export interface QualityRecommendation {
+  id: string;
+  type: QualityRecommendationType;
+  priority: RecommendationPriority;
+  title: string;
+  description: string;
+  
+  // Context
+  assetId?: string;
+  ruleId?: string;
+  issueId?: string;
+  
+  // Implementation
+  implementation: RecommendationImplementation;
+  estimatedEffort: EffortEstimate;
+  expectedImpact: ImpactEstimate;
+  
+  // Actions
+  actionItems: RecommendationActionItem[];
+  
+  // Validation
+  successCriteria: SuccessCriteria[];
+  
+  // Tracking
+  status: RecommendationStatus;
+  assignedTo?: string;
+  dueDate?: Date;
+  
+  // Feedback
+  feedback: RecommendationFeedback[];
+  
+  // Timestamps
+  createdAt: Date;
+  implementedAt?: Date;
+  validatedAt?: Date;
+}
+
+export interface QualityMonitoring {
+  id: string;
+  name: string;
+  description?: string;
+  
+  // Monitoring Scope
+  scope: MonitoringScope;
+  assets: string[];
+  
+  // Monitoring Rules
+  rules: QualityMonitoringRule[];
+  
+  // Alerting
+  alerting: QualityAlerting;
+  
+  // Scheduling
+  schedule: MonitoringSchedule;
+  
+  // Thresholds
+  thresholds: QualityThreshold[];
+  
+  // Status
+  status: MonitoringStatus;
+  lastRun: Date;
+  nextRun: Date;
+  
+  // Performance
+  performance: MonitoringPerformance;
+  
+  // History
+  executionHistory: MonitoringExecution[];
+}
+
+export interface QualityReport {
+  id: string;
+  name: string;
+  type: QualityReportType;
+  
+  // Report Configuration
+  config: QualityReportConfig;
+  template: ReportTemplate;
+  
+  // Data
+  data: QualityReportData;
+  
+  // Sections
+  sections: QualityReportSection[];
+  
+  // Visualization
+  charts: QualityChart[];
+  tables: QualityTable[];
+  
+  // Metadata
+  metadata: QualityReportMetadata;
+  
+  // Distribution
+  recipients: ReportRecipient[];
+  distributionSchedule: DistributionSchedule;
+  
+  // Status
+  status: ReportStatus;
+  generatedAt: Date;
+  
+  // Export Options
+  exportFormats: ExportFormat[];
+  
+  // Access Control
+  accessControl: ReportAccessControl;
+}
+
+// ============================================================================
+// QUALITY PROFILING & ANALYSIS TYPES
+// ============================================================================
+
+export interface QualityProfile {
+  id: string;
+  assetId: string;
+  profileType: QualityProfileType;
+  
+  // Profile Data
+  profileData: ProfileData;
+  
+  // Statistical Analysis
+  statistics: QualityStatistics;
+  
+  // Pattern Analysis
+  patterns: QualityPattern[];
+  
+  // Anomaly Detection
+  anomalies: QualityAnomaly[];
+  
+  // Baseline Comparison
+  baseline: QualityBaseline;
+  deviation: QualityDeviation;
+  
+  // Timestamps
+  profiledAt: Date;
+  validFrom: Date;
+  validTo?: Date;
+}
+
+export interface QualityBaseline {
+  id: string;
+  assetId: string;
+  baselineType: BaselineType;
+  
+  // Baseline Metrics
+  metrics: BaselineMetric[];
+  
+  // Statistical Baselines
+  statisticalBaseline: StatisticalBaseline;
+  
+  // Behavioral Baselines
+  behavioralBaseline: BehavioralBaseline;
+  
+  // Thresholds
+  thresholds: BaselineThreshold[];
+  
+  // Validity
+  validFrom: Date;
+  validTo?: Date;
+  confidence: number;
+  
+  // Maintenance
+  autoUpdate: boolean;
+  updateFrequency: UpdateFrequency;
+  lastUpdated: Date;
+}
+
+export interface QualityScoreTrend {
+  assetId: string;
+  period: TimePeriod;
+  dataPoints: ScoreTrendDataPoint[];
+  
+  // Trend Analysis
+  overallTrend: TrendDirection;
+  changeRate: number;
+  volatility: number;
+  
+  // Forecasting
+  forecast: ScoreForecast[];
+  confidence: number;
+  
+  // Insights
+  insights: TrendInsight[];
+  
+  // Anomalies
+  anomalies: TrendAnomaly[];
+}
+
+// ============================================================================
+// QUALITY RULE ENGINE TYPES
+// ============================================================================
+
+export interface QualityRuleEngine {
+  id: string;
+  version: string;
+  
+  // Engine Configuration
+  config: RuleEngineConfig;
+  
+  // Rule Library
+  ruleLibrary: QualityRuleLibrary;
+  
+  // Execution Engine
+  executionEngine: RuleExecutionEngine;
+  
+  // Performance
+  performance: EnginePerformance;
+  
+  // Status
+  status: EngineStatus;
+  
+  // Monitoring
+  monitoring: EngineMonitoring;
+}
+
+export interface QualityRuleLibrary {
+  id: string;
+  name: string;
+  version: string;
+  
+  // Categories
+  categories: RuleCategory[];
+  
+  // Built-in Rules
+  builtInRules: BuiltInRule[];
+  
+  // Custom Rules
+  customRules: CustomRule[];
+  
+  // Rule Templates
+  ruleTemplates: RuleTemplate[];
+  
+  // Dependencies
+  dependencies: RuleDependency[];
+  
+  // Validation
+  validation: LibraryValidation;
+}
+
+// ============================================================================
+// QUALITY AUTOMATION TYPES
+// ============================================================================
+
+export interface QualityAutomation {
+  id: string;
+  name: string;
+  type: AutomationType;
+  
+  // Automation Configuration
+  config: AutomationConfig;
+  
+  // Triggers
+  triggers: AutomationTrigger[];
+  
+  // Actions
+  actions: AutomationAction[];
+  
+  // Conditions
+  conditions: AutomationCondition[];
+  
+  // Execution
+  execution: AutomationExecution;
+  
+  // Status
+  status: AutomationStatus;
+  enabled: boolean;
+  
+  // History
+  executionHistory: AutomationExecutionHistory[];
+  
+  // Performance
+  performance: AutomationPerformance;
+}
+
+export interface QualityGovernance {
+  id: string;
+  name: string;
+  
+  // Policies
+  policies: QualityPolicy[];
+  
+  // Standards
+  standards: QualityStandard[];
+  
+  // Compliance
+  compliance: QualityCompliance;
+  
+  // Roles & Responsibilities
+  roles: QualityRole[];
+  responsibilities: QualityResponsibility[];
+  
+  // Approval Workflows
+  approvalWorkflows: QualityApprovalWorkflow[];
+  
+  // Audit Trail
+  auditTrail: QualityAuditEvent[];
+  
+  // Metrics
+  governanceMetrics: GovernanceMetric[];
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum QualityWidgetType {
+  SCORE_CARD = 'SCORE_CARD',
+  TREND_CHART = 'TREND_CHART',
+  ISSUE_SUMMARY = 'ISSUE_SUMMARY',
+  RULE_STATUS = 'RULE_STATUS',
+  HEAT_MAP = 'HEAT_MAP',
+  DISTRIBUTION_CHART = 'DISTRIBUTION_CHART',
+  COMPARISON_CHART = 'COMPARISON_CHART',
+  KPI_INDICATOR = 'KPI_INDICATOR'
+}
+
+export enum QualityJobStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  CANCELLED = 'CANCELLED',
+  PAUSED = 'PAUSED'
+}
+
+export enum QualityAssessmentStatus {
+  EXCELLENT = 'EXCELLENT',
+  GOOD = 'GOOD',
+  FAIR = 'FAIR',
+  POOR = 'POOR',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum RuleExecutionStatus {
+  SUCCESS = 'SUCCESS',
+  FAILURE = 'FAILURE',
+  WARNING = 'WARNING',
+  SKIPPED = 'SKIPPED',
+  ERROR = 'ERROR'
+}
+
+export enum QualityIssueType {
+  COMPLETENESS = 'COMPLETENESS',
+  ACCURACY = 'ACCURACY',
+  CONSISTENCY = 'CONSISTENCY',
+  VALIDITY = 'VALIDITY',
+  UNIQUENESS = 'UNIQUENESS',
+  TIMELINESS = 'TIMELINESS',
+  INTEGRITY = 'INTEGRITY',
+  CONFORMITY = 'CONFORMITY'
+}
+
+export enum QualityIssueSeverity {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL',
+  BLOCKING = 'BLOCKING'
+}
+
+export enum IssueStatus {
+  OPEN = 'OPEN',
+  IN_PROGRESS = 'IN_PROGRESS',
+  RESOLVED = 'RESOLVED',
+  CLOSED = 'CLOSED',
+  REOPENED = 'REOPENED',
+  DEFERRED = 'DEFERRED'
+}
+
+export enum TrendDirection {
+  IMPROVING = 'IMPROVING',
+  DECLINING = 'DECLINING',
+  STABLE = 'STABLE',
+  VOLATILE = 'VOLATILE',
+  UNKNOWN = 'UNKNOWN'
+}
+
+export enum QualityRecommendationType {
+  RULE_ENHANCEMENT = 'RULE_ENHANCEMENT',
+  THRESHOLD_ADJUSTMENT = 'THRESHOLD_ADJUSTMENT',
+  DATA_CLEANSING = 'DATA_CLEANSING',
+  PROCESS_IMPROVEMENT = 'PROCESS_IMPROVEMENT',
+  AUTOMATION = 'AUTOMATION',
+  MONITORING = 'MONITORING',
+  TRAINING = 'TRAINING'
+}
+
+export enum RecommendationPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum RecommendationStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  IMPLEMENTED = 'IMPLEMENTED',
+  VALIDATED = 'VALIDATED',
+  REJECTED = 'REJECTED',
+  DEFERRED = 'DEFERRED'
+}
+
+export enum MonitoringStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  PAUSED = 'PAUSED',
+  ERROR = 'ERROR',
+  MAINTENANCE = 'MAINTENANCE'
+}
+
+export enum QualityReportType {
+  EXECUTIVE_SUMMARY = 'EXECUTIVE_SUMMARY',
+  DETAILED_ANALYSIS = 'DETAILED_ANALYSIS',
+  TREND_REPORT = 'TREND_REPORT',
+  COMPLIANCE_REPORT = 'COMPLIANCE_REPORT',
+  ISSUE_REPORT = 'ISSUE_REPORT',
+  SCORECARD = 'SCORECARD',
+  BENCHMARK = 'BENCHMARK'
+}
+
+export enum ReportStatus {
+  GENERATING = 'GENERATING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+  SCHEDULED = 'SCHEDULED',
+  DISTRIBUTED = 'DISTRIBUTED'
+}
+
+export enum AutomationType {
+  QUALITY_MONITORING = 'QUALITY_MONITORING',
+  ISSUE_RESOLUTION = 'ISSUE_RESOLUTION',
+  ALERTING = 'ALERTING',
+  REPORTING = 'REPORTING',
+  DATA_CLEANSING = 'DATA_CLEANSING',
+  RULE_OPTIMIZATION = 'RULE_OPTIMIZATION'
+}
+
+export enum AutomationStatus {
+  ENABLED = 'ENABLED',
+  DISABLED = 'DISABLED',
+  PAUSED = 'PAUSED',
+  ERROR = 'ERROR'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface QualityDimensionScore {
+  dimension: string;
+  score: number;
+  weight: number;
+  contribution: number;
+  trend: TrendDirection;
+  issues: number;
+}
+
+export interface QualityJobProgress {
+  totalSteps: number;
+  completedSteps: number;
+  currentStep: string;
+  percentage: number;
+  estimatedTimeRemaining: number;
+}
+
+export interface QualityJobSummary {
+  totalAssets: number;
+  assessedAssets: number;
+  passedAssets: number;
+  failedAssets: number;
+  averageScore: number;
+  totalIssues: number;
+  criticalIssues: number;
+}
+
+export interface QualityThreshold {
+  name: string;
+  value: number;
+  operator: ThresholdOperator;
+  severity: QualityIssueSeverity;
+  enabled: boolean;
+}
+
+export interface BusinessImpact {
+  level: ImpactLevel;
+  description: string;
+  affectedProcesses: string[];
+  estimatedCost: number;
+  riskLevel: RiskLevel;
+}
+
+export interface TechnicalImpact {
+  level: ImpactLevel;
+  description: string;
+  affectedSystems: string[];
+  performanceImpact: PerformanceImpact;
+  scalabilityImpact: ScalabilityImpact;
+}
+
+export interface QualityForecast {
+  date: Date;
+  predictedScore: number;
+  confidence: number;
+  factors: ForecastFactor[];
+}
+
+export interface EffortEstimate {
+  timeEstimate: number;
+  resourcesRequired: string[];
+  complexity: ComplexityLevel;
+  dependencies: string[];
+}
+
+export interface ImpactEstimate {
+  qualityImprovement: number;
+  costSavings: number;
+  riskReduction: number;
+  businessValue: number;
+}
+
+export enum ThresholdOperator {
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  EQUALS = 'EQUALS',
+  NOT_EQUALS = 'NOT_EQUALS',
+  BETWEEN = 'BETWEEN'
+}
+
+export enum ImpactLevel {
+  MINIMAL = 'MINIMAL',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  SEVERE = 'SEVERE'
+}
+
+export enum RiskLevel {
+  VERY_LOW = 'VERY_LOW',
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  VERY_HIGH = 'VERY_HIGH',
+  CRITICAL = 'CRITICAL'
+}
+
+export enum ComplexityLevel {
+  SIMPLE = 'SIMPLE',
+  MODERATE = 'MODERATE',
+  COMPLEX = 'COMPLEX',
+  VERY_COMPLEX = 'VERY_COMPLEX'
+}

--- a/v15_enhanced_1/components/Advanced-Catalog/types/search.types.ts
+++ b/v15_enhanced_1/components/Advanced-Catalog/types/search.types.ts
@@ -1,0 +1,766 @@
+// ============================================================================
+// ADVANCED CATALOG SEARCH TYPES - ENTERPRISE DATA GOVERNANCE SYSTEM
+// ============================================================================
+// Maps to: semantic_search_service.py, enterprise_catalog_routes.py search endpoints
+// ============================================================================
+
+import { 
+  IntelligentDataAsset, 
+  BusinessGlossaryTerm,
+  TimePeriod,
+  SemanticEmbedding 
+} from './catalog-core.types';
+
+// ============================================================================
+// SEMANTIC SEARCH TYPES (semantic_search_service.py)
+// ============================================================================
+
+export interface SemanticSearchEngine {
+  id: string;
+  name: string;
+  version: string;
+  
+  // Engine Configuration
+  config: SearchEngineConfig;
+  
+  // Search Capabilities
+  capabilities: SearchCapabilities;
+  
+  // Indexing
+  indexing: SearchIndexing;
+  
+  // Query Processing
+  queryProcessor: QueryProcessor;
+  
+  // Ranking
+  rankingEngine: RankingEngine;
+  
+  // Performance
+  performance: SearchEnginePerformance;
+  
+  // Status
+  status: SearchEngineStatus;
+}
+
+export interface SearchRequest {
+  id: string;
+  query: string;
+  searchType: SearchType;
+  
+  // Context
+  context: SearchContext;
+  
+  // Filters
+  filters: SearchFilter[];
+  
+  // Facets
+  facets: SearchFacet[];
+  
+  // Pagination
+  pagination: SearchPagination;
+  
+  // Sorting
+  sorting: SearchSorting[];
+  
+  // Highlighting
+  highlighting: SearchHighlighting;
+  
+  // Personalization
+  personalization: SearchPersonalization;
+  
+  // Configuration
+  config: SearchRequestConfig;
+}
+
+export interface SearchResponse {
+  id: string;
+  requestId: string;
+  
+  // Results
+  results: SearchResult[];
+  totalResults: number;
+  
+  // Facets
+  facets: SearchFacetResult[];
+  
+  // Suggestions
+  suggestions: SearchSuggestion[];
+  
+  // Corrections
+  corrections: SearchCorrection[];
+  
+  // Related Queries
+  relatedQueries: RelatedQuery[];
+  
+  // Performance
+  performance: SearchPerformance;
+  
+  // Metadata
+  metadata: SearchResponseMetadata;
+  
+  // Timestamps
+  executedAt: Date;
+  duration: number;
+}
+
+export interface SearchResult {
+  id: string;
+  
+  // Result Data
+  asset?: IntelligentDataAsset;
+  term?: BusinessGlossaryTerm;
+  
+  // Relevance
+  score: number;
+  relevance: SearchRelevance;
+  
+  // Highlighting
+  highlights: SearchHighlight[];
+  
+  // Explanation
+  explanation: SearchExplanation;
+  
+  // Context
+  context: SearchResultContext;
+  
+  // Metadata
+  metadata: SearchResultMetadata;
+  
+  // Actions
+  actions: SearchResultAction[];
+}
+
+export interface NaturalLanguageQuery {
+  id: string;
+  originalQuery: string;
+  
+  // Query Understanding
+  intent: QueryIntent;
+  entities: QueryEntity[];
+  
+  // Query Processing
+  processedQuery: ProcessedQuery;
+  
+  // Transformation
+  transformation: QueryTransformation;
+  
+  // Semantic Analysis
+  semanticAnalysis: SemanticAnalysis;
+  
+  // Confidence
+  confidence: number;
+  
+  // Alternatives
+  alternatives: AlternativeQuery[];
+}
+
+export interface SearchPersonalization {
+  userId?: string;
+  
+  // User Profile
+  userProfile: UserSearchProfile;
+  
+  // Preferences
+  preferences: SearchPreferences;
+  
+  // History
+  searchHistory: SearchHistoryItem[];
+  
+  // Behavior
+  behavior: SearchBehaviorProfile;
+  
+  // Context
+  personalContext: PersonalSearchContext;
+  
+  // Recommendations
+  personalizedRecommendations: PersonalizedSearchRecommendation[];
+}
+
+export interface SearchAnalytics {
+  id: string;
+  period: TimePeriod;
+  
+  // Query Analytics
+  queryAnalytics: QueryAnalytics;
+  
+  // User Analytics
+  userAnalytics: SearchUserAnalytics;
+  
+  // Performance Analytics
+  performanceAnalytics: SearchPerformanceAnalytics;
+  
+  // Content Analytics
+  contentAnalytics: SearchContentAnalytics;
+  
+  // Trend Analysis
+  trendAnalysis: SearchTrendAnalysis;
+  
+  // Insights
+  insights: SearchInsight[];
+  
+  // Recommendations
+  optimizationRecommendations: SearchOptimizationRecommendation[];
+}
+
+// ============================================================================
+// UNIFIED SEARCH TYPES
+// ============================================================================
+
+export interface UnifiedSearchInterface {
+  id: string;
+  name: string;
+  
+  // Search Scope
+  scope: UnifiedSearchScope;
+  
+  // Search Domains
+  domains: SearchDomain[];
+  
+  // Federated Search
+  federatedSearch: FederatedSearchConfig;
+  
+  // Cross-Domain Ranking
+  crossDomainRanking: CrossDomainRankingConfig;
+  
+  // Result Aggregation
+  resultAggregation: ResultAggregationConfig;
+  
+  // Unified Filters
+  unifiedFilters: UnifiedSearchFilter[];
+  
+  // Performance
+  performance: UnifiedSearchPerformance;
+}
+
+export interface FederatedSearchConfig {
+  id: string;
+  
+  // Search Sources
+  sources: FederatedSearchSource[];
+  
+  // Orchestration
+  orchestration: FederatedOrchestration;
+  
+  // Result Merging
+  resultMerging: ResultMergingStrategy;
+  
+  // Timeout Configuration
+  timeouts: FederatedTimeoutConfig;
+  
+  // Fallback Strategy
+  fallbackStrategy: FederatedFallbackStrategy;
+  
+  // Quality Control
+  qualityControl: FederatedQualityControl;
+}
+
+export interface SearchRecommendationEngine {
+  id: string;
+  name: string;
+  
+  // Recommendation Types
+  types: SearchRecommendationType[];
+  
+  // Algorithms
+  algorithms: RecommendationAlgorithm[];
+  
+  // Personalization
+  personalization: RecommendationPersonalization;
+  
+  // Context Awareness
+  contextAwareness: RecommendationContextAwareness;
+  
+  // Feedback Loop
+  feedbackLoop: RecommendationFeedbackLoop;
+  
+  // Performance
+  performance: RecommendationEnginePerformance;
+}
+
+// ============================================================================
+// ADVANCED SEARCH FEATURES
+// ============================================================================
+
+export interface SearchAutoComplete {
+  id: string;
+  
+  // Suggestions
+  suggestions: AutoCompleteSuggestion[];
+  
+  // Categories
+  categories: AutoCompleteCategory[];
+  
+  // Personalization
+  personalized: boolean;
+  personalizedSuggestions: PersonalizedSuggestion[];
+  
+  // Performance
+  responseTime: number;
+  
+  // Configuration
+  config: AutoCompleteConfig;
+}
+
+export interface SearchFiltering {
+  id: string;
+  
+  // Available Filters
+  availableFilters: AvailableFilter[];
+  
+  // Active Filters
+  activeFilters: ActiveFilter[];
+  
+  // Filter Dependencies
+  dependencies: FilterDependency[];
+  
+  // Dynamic Filters
+  dynamicFilters: DynamicFilter[];
+  
+  // Filter Analytics
+  analytics: FilterAnalytics;
+}
+
+export interface SearchFaceting {
+  id: string;
+  
+  // Facet Configuration
+  config: FacetConfig;
+  
+  // Facet Results
+  facetResults: FacetResult[];
+  
+  // Hierarchical Facets
+  hierarchicalFacets: HierarchicalFacet[];
+  
+  // Range Facets
+  rangeFacets: RangeFacet[];
+  
+  // Custom Facets
+  customFacets: CustomFacet[];
+}
+
+export interface SearchSuggestionEngine {
+  id: string;
+  
+  // Suggestion Types
+  types: SuggestionType[];
+  
+  // Suggestion Sources
+  sources: SuggestionSource[];
+  
+  // Machine Learning
+  mlModels: SuggestionMLModel[];
+  
+  // Real-time Suggestions
+  realTimeSuggestions: RealTimeSuggestion[];
+  
+  // Performance
+  performance: SuggestionEnginePerformance;
+}
+
+// ============================================================================
+// SEARCH MONITORING & OPTIMIZATION
+// ============================================================================
+
+export interface SearchMonitoring {
+  id: string;
+  
+  // Performance Monitoring
+  performanceMonitoring: SearchPerformanceMonitoring;
+  
+  // Quality Monitoring
+  qualityMonitoring: SearchQualityMonitoring;
+  
+  // User Experience Monitoring
+  uxMonitoring: SearchUXMonitoring;
+  
+  // System Health
+  systemHealth: SearchSystemHealth;
+  
+  // Alerts
+  alerts: SearchAlert[];
+  
+  // Reports
+  reports: SearchMonitoringReport[];
+}
+
+export interface SearchOptimization {
+  id: string;
+  
+  // Query Optimization
+  queryOptimization: QueryOptimization;
+  
+  // Index Optimization
+  indexOptimization: IndexOptimization;
+  
+  // Ranking Optimization
+  rankingOptimization: RankingOptimization;
+  
+  // Performance Optimization
+  performanceOptimization: SearchPerformanceOptimization;
+  
+  // A/B Testing
+  abTesting: SearchABTesting;
+  
+  // Recommendations
+  optimizationRecommendations: OptimizationRecommendation[];
+}
+
+export interface SearchConfiguration {
+  id: string;
+  name: string;
+  
+  // Engine Configuration
+  engineConfig: SearchEngineConfiguration;
+  
+  // Index Configuration
+  indexConfig: SearchIndexConfiguration;
+  
+  // Query Configuration
+  queryConfig: SearchQueryConfiguration;
+  
+  // Ranking Configuration
+  rankingConfig: SearchRankingConfiguration;
+  
+  // UI Configuration
+  uiConfig: SearchUIConfiguration;
+  
+  // Advanced Settings
+  advancedSettings: SearchAdvancedSettings;
+}
+
+// ============================================================================
+// ENUM DEFINITIONS
+// ============================================================================
+
+export enum SearchType {
+  KEYWORD = 'KEYWORD',
+  SEMANTIC = 'SEMANTIC',
+  NATURAL_LANGUAGE = 'NATURAL_LANGUAGE',
+  FACETED = 'FACETED',
+  FUZZY = 'FUZZY',
+  BOOLEAN = 'BOOLEAN',
+  PHRASE = 'PHRASE',
+  WILDCARD = 'WILDCARD'
+}
+
+export enum SearchEngineStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  INDEXING = 'INDEXING',
+  MAINTENANCE = 'MAINTENANCE',
+  ERROR = 'ERROR'
+}
+
+export enum QueryIntent {
+  FIND_ASSET = 'FIND_ASSET',
+  FIND_DEFINITION = 'FIND_DEFINITION',
+  FIND_LINEAGE = 'FIND_LINEAGE',
+  FIND_USAGE = 'FIND_USAGE',
+  FIND_QUALITY = 'FIND_QUALITY',
+  FIND_OWNER = 'FIND_OWNER',
+  FIND_SIMILAR = 'FIND_SIMILAR',
+  EXPLORE = 'EXPLORE'
+}
+
+export enum SearchRecommendationType {
+  QUERY_SUGGESTION = 'QUERY_SUGGESTION',
+  RESULT_RECOMMENDATION = 'RESULT_RECOMMENDATION',
+  FILTER_SUGGESTION = 'FILTER_SUGGESTION',
+  SIMILAR_SEARCH = 'SIMILAR_SEARCH',
+  TRENDING_SEARCH = 'TRENDING_SEARCH',
+  PERSONALIZED = 'PERSONALIZED'
+}
+
+export enum SuggestionType {
+  QUERY_COMPLETION = 'QUERY_COMPLETION',
+  SPELL_CORRECTION = 'SPELL_CORRECTION',
+  SYNONYM_EXPANSION = 'SYNONYM_EXPANSION',
+  RELATED_TERMS = 'RELATED_TERMS',
+  POPULAR_SEARCHES = 'POPULAR_SEARCHES',
+  TRENDING_SEARCHES = 'TRENDING_SEARCHES'
+}
+
+export enum FilterType {
+  TEXT = 'TEXT',
+  NUMERIC = 'NUMERIC',
+  DATE = 'DATE',
+  BOOLEAN = 'BOOLEAN',
+  LIST = 'LIST',
+  RANGE = 'RANGE',
+  HIERARCHICAL = 'HIERARCHICAL',
+  GEO = 'GEO'
+}
+
+export enum FacetType {
+  TERMS = 'TERMS',
+  RANGE = 'RANGE',
+  DATE_HISTOGRAM = 'DATE_HISTOGRAM',
+  NESTED = 'NESTED',
+  FILTER = 'FILTER',
+  QUERY = 'QUERY'
+}
+
+export enum SortOrder {
+  RELEVANCE = 'RELEVANCE',
+  POPULARITY = 'POPULARITY',
+  RECENCY = 'RECENCY',
+  ALPHABETICAL = 'ALPHABETICAL',
+  CUSTOM = 'CUSTOM'
+}
+
+export enum SearchScope {
+  ASSETS = 'ASSETS',
+  GLOSSARY = 'GLOSSARY',
+  LINEAGE = 'LINEAGE',
+  QUALITY = 'QUALITY',
+  DOCUMENTATION = 'DOCUMENTATION',
+  ALL = 'ALL'
+}
+
+// ============================================================================
+// SUPPORTING TYPES
+// ============================================================================
+
+export interface SearchFilter {
+  field: string;
+  type: FilterType;
+  operator: FilterOperator;
+  value: any;
+  values?: any[];
+  enabled: boolean;
+}
+
+export interface SearchFacet {
+  field: string;
+  type: FacetType;
+  size: number;
+  minCount?: number;
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface SearchPagination {
+  page: number;
+  size: number;
+  offset: number;
+  maxSize: number;
+}
+
+export interface SearchSorting {
+  field: string;
+  order: SortOrder;
+  direction: SortDirection;
+}
+
+export interface SearchHighlighting {
+  enabled: boolean;
+  fields: string[];
+  fragmentSize: number;
+  numberOfFragments: number;
+  preTag: string;
+  postTag: string;
+}
+
+export interface SearchContext {
+  userId?: string;
+  sessionId: string;
+  userAgent: string;
+  location?: SearchLocation;
+  timestamp: Date;
+  referrer?: string;
+}
+
+export interface SearchRelevance {
+  score: number;
+  factors: RelevanceFactor[];
+  explanation: string;
+  boost: number;
+}
+
+export interface SearchHighlight {
+  field: string;
+  fragments: string[];
+  matched: boolean;
+}
+
+export interface SearchExplanation {
+  description: string;
+  value: number;
+  details: ExplanationDetail[];
+}
+
+export interface QueryEntity {
+  text: string;
+  type: EntityType;
+  confidence: number;
+  start: number;
+  end: number;
+}
+
+export interface SearchPreferences {
+  defaultSort: SortOrder;
+  resultsPerPage: number;
+  enablePersonalization: boolean;
+  enableSuggestions: boolean;
+  enableHighlighting: boolean;
+  preferredDomains: string[];
+}
+
+export interface SearchHistoryItem {
+  query: string;
+  timestamp: Date;
+  results: number;
+  clicked: boolean;
+  clickedResult?: string;
+}
+
+export interface AutoCompleteSuggestion {
+  text: string;
+  type: SuggestionType;
+  score: number;
+  category: string;
+  metadata: Record<string, any>;
+}
+
+export interface FacetResult {
+  field: string;
+  type: FacetType;
+  buckets: FacetBucket[];
+  otherCount?: number;
+  error?: string;
+}
+
+export interface FacetBucket {
+  key: string;
+  count: number;
+  selected: boolean;
+  subFacets?: FacetResult[];
+}
+
+export enum FilterOperator {
+  EQUALS = 'EQUALS',
+  NOT_EQUALS = 'NOT_EQUALS',
+  CONTAINS = 'CONTAINS',
+  NOT_CONTAINS = 'NOT_CONTAINS',
+  STARTS_WITH = 'STARTS_WITH',
+  ENDS_WITH = 'ENDS_WITH',
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  NOT_IN = 'NOT_IN'
+}
+
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC'
+}
+
+export enum EntityType {
+  ASSET_NAME = 'ASSET_NAME',
+  COLUMN_NAME = 'COLUMN_NAME',
+  BUSINESS_TERM = 'BUSINESS_TERM',
+  OWNER = 'OWNER',
+  TAG = 'TAG',
+  DOMAIN = 'DOMAIN',
+  DATE = 'DATE',
+  NUMBER = 'NUMBER'
+}
+
+export interface SearchLocation {
+  country?: string;
+  region?: string;
+  city?: string;
+  timezone?: string;
+}
+
+export interface RelevanceFactor {
+  name: string;
+  weight: number;
+  contribution: number;
+  explanation: string;
+}
+
+export interface ExplanationDetail {
+  description: string;
+  value: number;
+  details?: ExplanationDetail[];
+}
+
+// ============================================================================
+// SEARCH PERFORMANCE & ANALYTICS TYPES
+// ============================================================================
+
+export interface SearchPerformance {
+  totalTime: number;
+  queryTime: number;
+  fetchTime: number;
+  processingTime: number;
+  
+  // Cache Performance
+  cacheHitRate: number;
+  cacheSize: number;
+  
+  // Resource Usage
+  memoryUsage: number;
+  cpuUsage: number;
+  
+  // Throughput
+  queriesPerSecond: number;
+  
+  // Errors
+  errorRate: number;
+  errors: SearchError[];
+}
+
+export interface QueryAnalytics {
+  totalQueries: number;
+  uniqueQueries: number;
+  averageQueryLength: number;
+  
+  // Query Types
+  queryTypes: QueryTypeAnalytics[];
+  
+  // Popular Queries
+  popularQueries: PopularQuery[];
+  
+  // Query Success Rate
+  successRate: number;
+  noResultsRate: number;
+  
+  // Query Patterns
+  queryPatterns: QueryPattern[];
+}
+
+export interface SearchUserAnalytics {
+  totalUsers: number;
+  activeUsers: number;
+  newUsers: number;
+  
+  // User Behavior
+  averageSessionDuration: number;
+  averageQueriesPerSession: number;
+  bounceRate: number;
+  
+  // User Segments
+  userSegments: UserSegmentAnalytics[];
+  
+  // Engagement
+  engagementMetrics: SearchEngagementMetrics;
+}
+
+export interface SearchError {
+  type: SearchErrorType;
+  message: string;
+  timestamp: Date;
+  context: Record<string, any>;
+}
+
+export enum SearchErrorType {
+  QUERY_PARSE_ERROR = 'QUERY_PARSE_ERROR',
+  INDEX_ERROR = 'INDEX_ERROR',
+  TIMEOUT_ERROR = 'TIMEOUT_ERROR',
+  SYSTEM_ERROR = 'SYSTEM_ERROR',
+  AUTHORIZATION_ERROR = 'AUTHORIZATION_ERROR'
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement the foundational Advanced-Catalog frontend constants, schemas, and initial service layer to precisely map to the backend.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR establishes the core frontend architecture for the Advanced-Catalog group, including comprehensive constant definitions (system config, asset, quality, lineage, search, analytics, discovery, UI, notification, error), API endpoint mappings, and data schema definitions. It also introduces the `CatalogQualityService` to align with the backend's `catalog_quality_service.py`, ensuring a robust and type-safe foundation for future component development.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca3b1482-8ef6-453a-8808-65889f6c9feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca3b1482-8ef6-453a-8808-65889f6c9feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>